### PR TITLE
Added CodeSignatureVerifier step to EndNote8.download.recipe

### DIFF
--- a/EndNote/EndNoteX8.download.recipe
+++ b/EndNote/EndNoteX8.download.recipe
@@ -43,6 +43,17 @@
 			<key>Processor</key>
 			<string>Versioner</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Install EndNote X8.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.ThomsonReuters.InstallEndNote" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2Y4P62NL52")</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This is pretty much the standard requirement string that Xcode creates automatically when signing apps. The only changing attributes are `identifier` and `leaf[subject.OU]` which can be found by running `codesign --display -v -r- <app_path>`.