### PR TITLE
Preserve download

### DIFF
--- a/EndNote/EndNoteX8.pkg.recipe
+++ b/EndNote/EndNoteX8.pkg.recipe
@@ -117,7 +117,6 @@
 			<dict>
 				<key>path_list</key>
 				<array>
-					<string>%RECIPE_CACHE_DIR%/EndNote.zip</string>
 					<string>%RECIPE_CACHE_DIR%/unarchive</string>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 				</array>


### PR DESCRIPTION
Trade disk space for recipe speed. No need to download the same file over and over.