### PR TITLE
.munki recipe for Privileges

### DIFF
--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Privileges.app and imports it into Munki</string>
+    <key>Identifier</key>
+    <string>com.github.rtrouton.munki.privileges</string>
+    <key>Input</key>
+    <dict>
+		<key>MUNKI_CATEGORY</key>
+		<string>Utilities</string>
+		<key>MUNKI_DEVELOPER</key>
+		<string>SAP</string>
+		<key>NAME</key>
+		<string>Privileges</string>
+		<key>DISPLAYNAME</key>
+		<string>Privileges</string>
+		<key>DESCRIPTION</key>
+		<string>Privileges.app for macOS is designed to allow users to work as a standard user for day-to-day use, by providing a quick and easy way to get administrator rights when needed. When you do need admin rights, you can get them by clicking on the Privileges icon in your Dock.</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>description</key>
+			<string>%DESCRIPTION%</string>
+			<key>developer</key>
+			<string>%MUNKI_DEVELOPER%</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>display_name</key>
+			<string>%DISPLAYNAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>   
+    <key>ParentRecipe</key>
+    <string>com.github.rtrouton.pkg.privileges</string>
+    <key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+    	</dict>
+	</array>
+</dict>
+</plist>

--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -4,11 +4,11 @@
 <dict>
 	<key>Description</key>
 	<string>Downloads the latest version of Privileges.app and imports it into Munki</string>
-    <key>Identifier</key>
-    <string>com.github.rtrouton.munki.privileges</string>
-    <key>Input</key>
-    <dict>
-		<key>MUNKI_CATEGORY</key>
+	<key>Identifier</key>
+	<string>com.github.rtrouton.munki.privileges</string>
+	<key>Input</key>
+	<dict>
+			<key>MUNKI_CATEGORY</key>
 		<string>Utilities</string>
 		<key>MUNKI_DEVELOPER</key>
 		<string>SAP</string>


### PR DESCRIPTION
Verified that this recipe will properly use Rich's .pkg recipe to generate a package and import it into Munki.

Since this uses the .pkg and not the .app as a source, it includes the privileged helper tool and the launchdaemon in the install.

Munki users might consider using dockutil to add the icon to the dock as a post install script (inside of munki, not the pkg itself)