### PR TITLE
Update MicrosoftTeams.pkg.recipe

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.pkg.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.pkg.recipe
@@ -71,7 +71,7 @@
                <key>source_pkg</key>
                <string>%pathname%</string>
                <key>pkg_path</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
+               <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
          </dict>
          <dict>


### PR DESCRIPTION
Changes the package name to be consistent with other recipes. This change also allows the package name to be overridable.