### PR TITLE
changed SEARCH_PATTERN to variable subdirectory

### DIFF
--- a/OpenJDK11/OpenJDK11.download.recipe
+++ b/OpenJDK11/OpenJDK11.download.recipe
@@ -19,7 +19,7 @@
         <key>SEARCH_URL</key>
         <string>https://jdk.java.net/11/index.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11\.[0-9\.]+_osx-x64_bin\.tar\.gz)</string>
+        <string>(?P&lt;url&gt;https://download.java.net/java/GA/jdk11/.*?/GPL/openjdk-11\.[0-9\.]+_osx-x64_bin\.tar\.gz)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>


### PR DESCRIPTION
Changed SEARCH_PATTERN to variable subdirectory (the numbered directory at `https://download.java.net/java/GA/jdk11/` is currently `7` but is hard-coded as `13` in this recipe; could just change to `7` but it's probably going to work better going forward with a catch-all). As-is, the recipe returns error:

> Error in com.github.rtrouton.download.OpenJDK11: Processor: URLTextSearcher: Error: No match found on URL: https://jdk.java.net/11/index.html