### PR TITLE
 Remove variables in app paths

### DIFF
--- a/DetectX/DetectX.download.recipe
+++ b/DetectX/DetectX.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.sqwarq.DetectX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MAJ5XBJSG3)</string>
 			</dict>

--- a/EnterpriseConnect/EnterpriseConnect.pkg.recipe
+++ b/EnterpriseConnect/EnterpriseConnect.pkg.recipe
@@ -34,7 +34,7 @@
         	<key>Arguments</key>
         	<dict>
         		<key>pattern</key>
-        		<string>%RECIPE_CACHE_DIR%/unzip/%NAME%*/*.pkg</string>
+        		<string>%RECIPE_CACHE_DIR%/unzip/Enterprise Connect*/*.pkg</string>
         	</dict>
         </dict>
         <dict>
@@ -58,14 +58,14 @@
                 <key>extract_root</key>
                 <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>
-        </dict>            
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/Applications/Enterprise Connect.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -76,7 +76,7 @@
         	<key>Arguments</key>
         	<dict>
         		<key>pattern</key>
-        		<string>%RECIPE_CACHE_DIR%/unzip/%NAME%*/*.pkg</string>
+        		<string>%RECIPE_CACHE_DIR%/unzip/Enterprise Connect*/*.pkg</string>
         	</dict>
         </dict>
         <dict>
@@ -101,7 +101,7 @@
         </dict>
         <key>Processor</key>
         <string>PathDeleter</string>
-	</dict>                   	      	
+	</dict>
 	</array>
 </dict>
 </plist>

--- a/Icons/Icons.download.recipe
+++ b/Icons/Icons.download.recipe
@@ -56,7 +56,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Icons.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "corp.sap.Icons" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ")</string>
             </dict>

--- a/IntelliJ-CE/IntelliJ-CE.pkg.recipe
+++ b/IntelliJ-CE/IntelliJ-CE.pkg.recipe
@@ -48,7 +48,7 @@
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/IntelliJ IDEA CE.app</string>
             </dict>
         </dict>
         <dict>

--- a/MalwarebytesAntiMalware/MalwarebytesAntiMalware.pkg.recipe
+++ b/MalwarebytesAntiMalware/MalwarebytesAntiMalware.pkg.recipe
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/Malwarebytes Anti-Malware.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/MeisterTask/MeisterTask.pkg.recipe
+++ b/MeisterTask/MeisterTask.pkg.recipe
@@ -36,14 +36,14 @@
                 <key>extract_root</key>
                 <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>
-        </dict>            
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/MeisterTask.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -69,7 +69,7 @@
         </dict>
         <key>Processor</key>
         <string>PathDeleter</string>
-	</dict>                   	      	
+	</dict>
 	</array>
 </dict>
 </plist>

--- a/MountainDuck/MountainDuck.download.recipe
+++ b/MountainDuck/MountainDuck.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Mountain Duck.app</string>
 				<key>requirement</key>
 				<string>identifier "io.mountainduck" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = G69SCX94XU</string>
 			</dict>

--- a/MountainDuck/MountainDuck.install.recipe
+++ b/MountainDuck/MountainDuck.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Mountain Duck.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Packages/Packages.pkg.recipe
+++ b/Packages/Packages.pkg.recipe
@@ -32,18 +32,18 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/Packages.pkg/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>
-        </dict>            
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload//Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications/Packages.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -70,7 +70,7 @@
         </dict>
         <key>Processor</key>
         <string>PathDeleter</string>
-	</dict>                   	      	
+	</dict>
 	</array>
 </dict>
 </plist>

--- a/ParallelsTools/ParallelsTools.pkg.recipe
+++ b/ParallelsTools/ParallelsTools.pkg.recipe
@@ -21,7 +21,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/prl-tools-mac.iso</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Resources/Tools/prl-tools-mac.iso</string>
+				<string>%pathname%/Parallels Desktop.app/Contents/Resources/Tools/prl-tools-mac.iso</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -47,7 +47,7 @@
         </dict>
         <key>Processor</key>
         <string>PathDeleter</string>
-	</dict>                   	      	
+	</dict>
 	</array>
 </dict>
 </plist>

--- a/PasswordDepot/PasswordDepot.pkg.recipe
+++ b/PasswordDepot/PasswordDepot.pkg.recipe
@@ -45,14 +45,14 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>
-        </dict>            
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/PasswordDepot.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -79,7 +79,7 @@
         </dict>
         <key>Processor</key>
         <string>PathDeleter</string>
-	</dict>                   	      	
+	</dict>
 	</array>
 </dict>
 </plist>

--- a/Privileges/Privileges.download.recipe
+++ b/Privileges/Privileges.download.recipe
@@ -56,7 +56,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Privileges.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "corp.sap.privileges" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ")</string>
             </dict>


### PR DESCRIPTION
Using `%NAME%.app` will break path matching if the NAME variable is overridden.