### PR TITLE
Corrects CFBundleVersion/CFBundleShortVersionString in Fiji.app

### DIFF
--- a/Fiji/Fiji.pkg.recipe
+++ b/Fiji/Fiji.pkg.recipe
@@ -45,6 +45,24 @@
             </dict>
         </dict>
         <dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pkgroot%/Applications/Fiji.app/Contents/Info.plist</string>
+				<key>output_plist_path</key>
+				<string>%pkgroot%/Applications/Fiji.app/Contents/Info.plist</string>
+				<key>plist_data</key>
+				<dict>
+					<key>CFBundleShortVersionString</key>
+					<string>%version%</string>
+					<key>CFBundleVersion</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistEditor</string>
+		</dict>
+        <dict>
             <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
@@ -75,6 +93,17 @@
                 </dict>
             </dict>
         </dict>
+        <dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi Rich

The Fiji.app does not contain version information; `CFBundleVersion` just states `1.0`, and `CFBundleShortVersionString` is absent. This change to the `pkg` adds the correct version to the `Info.plist` file (or, at least, the version obtained from the `URLTextSearcher` process) so that Jamf knows what version we have installed. 

I also added a `PathDeleter` processor to clean up the processing files.