### PR TITLE
Basic python3 compatibility

### DIFF
--- a/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["OfficeSuiteSKULessVersionProvider"]
 
@@ -34,21 +37,21 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         },
     }
     description = __doc__
-    
+
     def get_version(self, FEED_URL):
         """Parse the macadmins.software/versions.xml feed for the latest O365 version number"""
         try:
-            raw_xml = urllib2.urlopen(FEED_URL)
+            raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
-        
+
         root = ET.fromstring(xml)
         latest = root.find('latest')
         for vers in root.iter('latest'):
             version = vers.find('o365').text
         return version
-    
+
     def main(self):
         self.env["version"] = self.get_version(FEED_URL)
         self.output("Found Version Number %s" % self.env["version"])

--- a/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import xml.etree.ElementTree as ET
 

--- a/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError

--- a/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365BusinessProSuite/OfficeSuiteSKULessVersionProvider.py
@@ -44,7 +44,7 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         try:
             raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
 
         root = ET.fromstring(xml)

--- a/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["OfficeSuiteSKULessVersionProvider"]
 
@@ -34,21 +37,21 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         },
     }
     description = __doc__
-    
+
     def get_version(self, FEED_URL):
         """Parse the macadmins.software/versions.xml feed for the latest O365 version number"""
         try:
-            raw_xml = urllib2.urlopen(FEED_URL)
+            raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
-        
+
         root = ET.fromstring(xml)
         latest = root.find('latest')
         for vers in root.iter('latest'):
             version = vers.find('o365').text
         return version
-    
+
     def main(self):
         self.env["version"] = self.get_version(FEED_URL)
         self.output("Found Version Number %s" % self.env["version"])

--- a/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import xml.etree.ElementTree as ET
 

--- a/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError

--- a/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
+++ b/MicrosoftOffice365Suite/OfficeSuiteSKULessVersionProvider.py
@@ -44,7 +44,7 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         try:
             raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
 
         root = ET.fromstring(xml)

--- a/PostProcessors/slacker.py
+++ b/PostProcessors/slacker.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 
 import subprocess
@@ -78,12 +80,12 @@ class Slacker(Processor):
             jss_policy_name = "%s" % jss_importer_summary_result["data"]["Policy"]
             jss_uploaded_package = "%s" % jss_importer_summary_result["data"]["Package"]
             output_title = "%s" % (prod_name)
-            print "JSS address: %s" % JSS_URL
-            print "Title: %s" % output_title
-            print "Policy: %s" % jss_policy_name
-            print "Package Added: %s" % jss_uploaded_package
-            print "Category: %s" % category
-            print "Policy Category: %s" % policy_category
+            print("JSS address: %s" % JSS_URL)
+            print("Title: %s" % output_title)
+            print("Policy: %s" % jss_policy_name)
+            print("Package Added: %s" % jss_uploaded_package)
+            print("Category: %s" % category)
+            print("Policy Category: %s" % policy_category)
             if jss_uploaded_package:
                 slack_text = "*New installer package added to Jamf Pro:*\nURL: %s\nTitle: *%s*\nCategory: *%s*\nPolicy Name: *%s*\nUploaded Package Name: *%s*" % (JSS_URL, output_title, category, jss_policy_name, jss_uploaded_package)
             else:

--- a/PostProcessors/slacker.py
+++ b/PostProcessors/slacker.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
-import subprocess
-import os.path
-import json
 import requests
+
+from autopkglib import Processor, ProcessorError
 
 # Set the webhook_url to the one provided by Slack when you create the webhook at https://my.slack.com/services/new/incoming-webhook/
 

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import re
-from xml.dom.minidom import parse, parseString
+from xml.dom.minidom import parseString
 
 from autopkglib import Processor, ProcessorError
 

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import re
 from xml.dom.minidom import parse, parseString
 import urllib2

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -42,7 +42,7 @@ class VMwareGuestToolsURLProvider(Processor):
         except BaseException as e:
             raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
-        build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
+        build_re = re.compile(r'^fusion\/([\d\.]+)\/(\d+)\/')
 
         last_build_no = 0
         last_url_part = None

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -18,61 +18,61 @@ DARWIN_TOOLS_URL_APPEND = 'packages/com.vmware.fusion.tools.darwin.zip.tar'
 DEFAULT_VERSION_SERIES = '11.1.0'
 
 class VMwareGuestToolsURLProvider(Processor):
-	'''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
+    '''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
 
-	input_variables = {
-		'VERSION_SERIES': {
-			'required': False,
-			'description': 'Version of VMware Fusion to target tools of. E.g. "8.0.0". Defaults to "8.0.0"',
-			},
-	}
-	output_variables = {
-		'url': {
-			'description': 'URL to the latest SourceForge project download'
-		}
-	}
+    input_variables = {
+        'VERSION_SERIES': {
+            'required': False,
+            'description': 'Version of VMware Fusion to target tools of. E.g. "8.0.0". Defaults to "8.0.0"',
+            },
+    }
+    output_variables = {
+        'url': {
+            'description': 'URL to the latest SourceForge project download'
+        }
+    }
 
-	def get_url(self, version_series):
-		try:
-			fusion_url = FUSION_URL_BASE + '/fusion.xml'
-			f = urlopen(fusion_url)
-			fusion_xml = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
+    def get_url(self, version_series):
+        try:
+            fusion_url = FUSION_URL_BASE + '/fusion.xml'
+            f = urlopen(fusion_url)
+            fusion_xml = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
-		build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
+        build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
 
-		last_build_no = 0
-		last_url_part = None
+        last_build_no = 0
+        last_url_part = None
 
-		fusion_feed = parseString(fusion_xml)
+        fusion_feed = parseString(fusion_xml)
 
-		for i in  fusion_feed.getElementsByTagName('metadata'):
-			productId = i.getElementsByTagName('productId')[0].firstChild.nodeValue
-			version = i.getElementsByTagName('version')[0].firstChild.nodeValue
-			url = i.getElementsByTagName('url')[0].firstChild.nodeValue
+        for i in  fusion_feed.getElementsByTagName('metadata'):
+            productId = i.getElementsByTagName('productId')[0].firstChild.nodeValue
+            version = i.getElementsByTagName('version')[0].firstChild.nodeValue
+            url = i.getElementsByTagName('url')[0].firstChild.nodeValue
 
-			if productId == 'fusion' and version == version_series:
+            if productId == 'fusion' and version == version_series:
 
-				match = build_re.search(url)
+                match = build_re.search(url)
 
-				if match:
-					build_ver = match.group(1)
-					build_no = match.group(2)
-					url_part = match.group(0)
+                if match:
+                    build_ver = match.group(1)
+                    build_no = match.group(2)
+                    url_part = match.group(0)
 
-					if build_no > last_build_no:
-						last_build_no = build_no
-						last_url_part = url_part
+                    if build_no > last_build_no:
+                        last_build_no = build_no
+                        last_url_part = url_part
 
-		if last_url_part:
-			return FUSION_URL_BASE + last_url_part + DARWIN_TOOLS_URL_APPEND
-		else:
-			raise ProcessorError('Could not find suitable version/build')
+        if last_url_part:
+            return FUSION_URL_BASE + last_url_part + DARWIN_TOOLS_URL_APPEND
+        else:
+            raise ProcessorError('Could not find suitable version/build')
 
-	def main(self):
-		version_series = self.env.get('VERSION_SERIES', DEFAULT_VERSION_SERIES)
+    def main(self):
+        version_series = self.env.get('VERSION_SERIES', DEFAULT_VERSION_SERIES)
 
-		self.env['url'] = self.get_url(version_series)
-		self.output('File URL %s' % self.env['url'])
+        self.env['url'] = self.get_url(version_series)
+        self.output('File URL %s' % self.env['url'])

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -3,9 +3,13 @@
 from __future__ import absolute_import
 import re
 from xml.dom.minidom import parse, parseString
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["VMwareGuestToolsURLProvider"]
 
@@ -31,7 +35,7 @@ class VMwareGuestToolsURLProvider(Processor):
 	def get_url(self, version_series):
 		try:
 			fusion_url = FUSION_URL_BASE + '/fusion.xml'
-			f = urllib2.urlopen(fusion_url)
+			f = urlopen(fusion_url)
 			fusion_xml = f.read()
 			f.close()
 		except BaseException as e:
@@ -72,4 +76,3 @@ class VMwareGuestToolsURLProvider(Processor):
 
 		self.env['url'] = self.get_url(version_series)
 		self.output('File URL %s' % self.env['url'])
-

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -39,7 +39,7 @@ class VMwareGuestToolsURLProvider(Processor):
             f = urlopen(fusion_url)
             fusion_xml = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
         build_re = re.compile(r'^fusion\/([\d\.]+)\/(\d+)\/')


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.