### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -17,7 +17,7 @@
     <array>
        <dict>
             <key>Processor</key>
-            <string>CURLTextSearcher</string>
+            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.