### PR TITLE
Generalize Zscaler download recipe so that you can use --pkg to specify a pre-downloaded package

### DIFF
--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -43,17 +43,6 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>Zscaler-osx-(?P&lt;version&gt;.*?)-installer.app.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -67,11 +56,20 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%VENDOR%/Zscaler-osx-*-installer.app</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%VENDOR%/Zscaler-osx-%version%-installer.app</string>
+                <string>%found_filename%</string>
                 <key>requirement</key>
                 <string>identifier "com.zscaler.installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PCBCQZJ7S7</string>
             </dict>

--- a/Zscaler/Zscaler.pkg.recipe
+++ b/Zscaler/Zscaler.pkg.recipe
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                <key>input_plist_path</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%/Zscaler-osx-%version%-installer.app/Contents/Info.plist</string>
+               <string>%found_filename%/Contents/Info.plist</string>
                <key>plist_version_key</key>
                <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
In some situations, you may want to use a newer or older version of the Zscaler installer than the one provided on the vendor download page. In the recipes' current form, this isn't possible because the `version` variable used to locate the app bundle is parsed from URLTextSearcher.

This PR uses FileFinder to find any valid installer path within the zip file, regardless of version. This allows administrators to provide an early-release download, or to backfill previous releases into their catalog. (For example: `autopkg run Zscaler.download --pkg /path/to/Zscaler-osx-1.5.2.6-installer.app.zip`)

Verbose logs to confirm the modified recipe runs as expected:  
https://gist.github.com/homebysix/1484af3bd13a40770b7c8a492fc0cc3d