### PR TITLE
Update OpenJDK12.download.recipe

### DIFF
--- a/OpenJDK12/OpenJDK12.download.recipe
+++ b/OpenJDK12/OpenJDK12.download.recipe
@@ -22,12 +22,12 @@
         <string>(?P&lt;url&gt;https://download.java.net/java/GA/jdk12.*?/GPL/openjdk-12\.[0-9\.]+_osx-x64_bin\.tar\.gz)</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>


### PR DESCRIPTION
With AutoPkg 1.1 (https://github.com/autopkg/autopkg/releases/tag/v1.1) DeprecationWarning became a core processor, so pointing to that instead of Greg Neagle's repo