### PR TITLE
VMwareTools recipes now use a more accurate version number

### DIFF
--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -3,8 +3,9 @@
 from __future__ import absolute_import
 
 import re
-from xml.dom.minidom import parseString
+from xml.etree import ElementTree
 from xml.parsers.expat import ExpatError
+from distutils.version import LooseVersion
 
 try:
     from urlparse import urljoin
@@ -16,7 +17,7 @@ from autopkglib import URLGetter, ProcessorError
 __all__ = ["VMwareGuestToolsURLProvider"]
 
 FUSION_URL_BASE = "https://softwareupdate.vmware.com/cds/vmw-desktop/"
-DARWIN_TOOLS_URL_APPEND = "core/com.vmware.fusion.zip.tar"
+DARWIN_TOOLS_URL_APPEND = "com.vmware.fusion.zip.tar"
 DEFAULT_VERSION_SERIES = "11.5.0"
 
 
@@ -28,64 +29,78 @@ class VMwareGuestToolsURLProvider(URLGetter):
             "required": False,
             "description": (
                 "Version of VMware Fusion to target tools of. E.g. "
-                '"8.0.0". Defaults to "8.0.0"'
+                '"11.5.0". Defaults to {}'.format(DEFAULT_VERSION_SERIES)
             ),
         }
     }
     output_variables = {
-        "url": {"description": "URL to the latest VMware Guest Tools download"}
+        "url": {"description": "URL to the latest VMware Guest Tools download"},
+        "version": {"description": "Version number of the VMware Guest Tools"},
     }
 
-    def get_url(self, version_series):
-        """Download the metadata from the base URL."""
+    def get_fusion_feed(self):
+        """Parse the XML feed into a data structure."""
         fusion_url = urljoin(FUSION_URL_BASE, "fusion.xml")
         self.output("Base URL: {}".format(fusion_url), verbose_level=2)
         fusion_xml = self.download(fusion_url, text=True)
+        return fusion_xml
 
+    def find_all_versions(self, fusion_feed, version_series):
+        """Find the highest version number in a minidom XML data structure.
+        Return a dictionary of version numbers to URL suffixes."""
         build_re = re.compile(r"^fusion\/([\d\.]+)\/(\d+)\/")
-
-        last_build_no = 0
-        last_url_part = None
-
-        try:
-            fusion_feed = parseString(fusion_xml)
-        except ExpatError:
-            raise ProcessorError(
-                "Unable to read XML data. The download was likely not XML."
-            )
-
-        for i in fusion_feed.getElementsByTagName("metadata"):
-            productId = i.getElementsByTagName("productId")[0].firstChild.nodeValue
-            version = i.getElementsByTagName("version")[0].firstChild.nodeValue
-            url = i.getElementsByTagName("url")[0].firstChild.nodeValue
-
-            if productId == "fusion" and version == version_series:
-
-                match = build_re.search(url)
-
-                if match:
-                    build_ver = match.group(1)
-                    build_no = int(match.group(2))
-                    url_part = match.group(0)
-                    self.output(
-                        "Match results: "
-                        "build_ver: {}, build_no: {}, url_part: {}".format(
-                            build_ver, build_no, url_part
-                        ),
-                        verbose_level=2,
+        versions = {}
+        for metadata in fusion_feed:
+            version = metadata.find("version")
+            url = metadata.find("url")
+            if version_series == "latest" or version.text in version_series:
+                # We actually want the URL, instead of the version itself
+                self.output(
+                    "Found version: {} with URL: {}".format(version.text, url.text),
+                    verbose_level=4,
+                )
+                match = build_re.search(url.text)
+                print(match.groups())
+                if match.groups():
+                    real_url = url.text.replace(
+                        "metadata.xml.gz", DARWIN_TOOLS_URL_APPEND
                     )
+                    versions[match.group(1)] = real_url
+        if not versions:
+            raise ProcessorError(
+                "Could not find any versions for the "
+                "major_version '{}'.".format(version_series)
+            )
+        return versions
 
-                    if build_no > last_build_no:
-                        last_build_no = build_no
-                        last_url_part = url_part
+    def find_highest_version(self, versions_dict):
+        """Find the URL of the highest version in the versions dictionary."""
+        return sorted(versions_dict.keys(), key=LooseVersion)[-1]
 
-        if last_url_part:
-            return urljoin(FUSION_URL_BASE, last_url_part + DARWIN_TOOLS_URL_APPEND)
+    def get_version_and_url(self, version_series):
+        """Return the version and URL string for the Guest Tools."""
+        fusion_xml = self.get_fusion_feed()
+        self.output("Searching for version series {}".format(version_series))
+        try:
+            fusion_feed = ElementTree.fromstring(fusion_xml)
+        except ExpatError:
+            raise ProcessorError("Unable to parse XML data from string.")
+        versions_dict = self.find_all_versions(fusion_feed, version_series)
+        latest_version_key = self.find_highest_version(versions_dict)
+        self.output(
+            "Latest version URL suffix: {}".format(versions_dict[latest_version_key]),
+            verbose_level=2,
+        )
+        full_url = urljoin(FUSION_URL_BASE, versions_dict[latest_version_key])
+
+        if full_url:
+            return (latest_version_key, full_url)
         else:
             raise ProcessorError("Could not find suitable version/build")
 
     def main(self):
-        version_series = self.env.get("VERSION_SERIES", DEFAULT_VERSION_SERIES)
-
-        self.env["url"] = self.get_url(version_series)
-        self.output("URL %s" % self.env["url"])
+        self.env["version"], self.env["url"] = self.get_version_and_url(
+            self.env.get("VERSION_SERIES", DEFAULT_VERSION_SERIES)
+        )
+        self.output("URL: {}".format(self.env["url"]))
+        self.output("Version: {}".format(self.env["version"]))

--- a/VMware-Tools/VMwareTools.download.recipe
+++ b/VMware-Tools/VMwareTools.download.recipe
@@ -40,8 +40,6 @@
 					<key>destination_path</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%-untar</string>
 				</dict>
-				<key>New item</key>
-				<string></string>
 			</dict>
 			<dict>
 				<key>Processor</key>
@@ -53,8 +51,6 @@
 					<key>destination_path</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				</dict>
-				<key>New item</key>
-				<string></string>
 			</dict>
 			<dict>
 				<key>Processor</key>

--- a/VMware-Tools/VMwareTools.pkg.recipe
+++ b/VMware-Tools/VMwareTools.pkg.recipe
@@ -17,17 +17,6 @@
         <array>
             <dict>
                 <key>Processor</key>
-                <string>Versioner</string>
-                <key>Arguments</key>
-                <dict>
-                    <key>input_plist_path</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%.iso/Install VMware Tools.app/Contents/Info.plist</string>
-                    <key>plist_version_key</key>
-                    <string>CFBundleShortVersionString</string>
-                </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
                 <string>Copier</string>
                 <key>Arguments</key>
                 <dict>


### PR DESCRIPTION
## Summary
Previously, VMwareTools used the version number of the "Install VMware Tools.app", which VMware didn't bump to reflect minor version updates. This meant that every version of the Guest Tools would use the same major version (in this case, "11.0.0"). This PR changes the provider to use the version number directly from the fusion.xml file, which matches the minor point version - such as "11.5.1".

I also changed the behavior of the VMwareGuestToolsURLProvider to break up the functionality into smaller functions. We use URLGetter to read in the fusion.xml file from the internet, and then we sort through all matching versions in the feed using ElementTree (instead of minidom). This lets us use LooseVersion to sort all matching version keys, rather than iterate through the whole list one by one.

The latest version is determined and used to generate the URL to the tools download.

This works on both AutoPkg 1.4.1 and 2.0b3.

### AutoPkg 1.4.1:
```
./autopkg run -vvvv VMwareTools.pkg
Processing VMwareTools.pkg...
WARNING: VMwareTools.pkg is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': u'1.4.1',
 u'CACHE_DIR': u'/Users/Shared/AutoPkg/Cache',
 u'MUNKI_REPO': u'/Users/Shared/munki_repo',
 u'NAME': u'VMwareTools',
 'PARENT_RECIPES': [u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools',
 'RECIPE_DIR': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 u'RECIPE_OVERRIDE_DIRS': [u'/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
 u'RECIPE_REPOS': {u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {u'URL': u'https://github.com/autopkg/jessepeterson-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {u'URL': u'https://github.com/autopkg/justinrummel-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {u'URL': u'https://github.com/autopkg/recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {u'URL': u'https://github.com/autopkg/rtrouton-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {u'URL': u'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 u'RECIPE_REPO_DIR': u'/Users/Shared/AutoPkg/RecipeRepos',
 u'RECIPE_SEARCH_DIRS': [u'.',
                         u'~/Library/AutoPkg/Recipes',
                         u'/Library/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 'verbose': 4}
VMwareGuestToolsURLProvider
{'Input': {}}
VMwareGuestToolsURLProvider: Base URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareGuestToolsURLProvider: Searching for version series 11.5.0
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.1/15018442/core/metadata.xml.gz
('11.5.1', '15018442')
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.0/14634996/core/metadata.xml.gz
('11.5.0', '14634996')
VMwareGuestToolsURLProvider: Latest version URL suffix: fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: Version: 11.5.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
            'version': '11.5.1'}}
URLDownloader
{'Input': {'filename': u'VMwareTools.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar
{'Output': {'pathname': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar'}}
Unarchiver: Guessed archive format 'tar' from filename VMwareTools.zip.tar
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar
{'Output': {}}
Unarchiver
{'Input': {'archive_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
           'destination_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools'}}
Unarchiver: Guessed archive format 'zip' from filename com.vmware.fusion.zip
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools
{'Output': {}}
FileMover
{'Input': {'source': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso',
           'target': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso'}}
FileMover: File /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso moved to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
{'Output': {}}
Copier
{'Input': {'destination_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
           'source_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso/Install VMware Tools.app'}}
Copier: Mounted disk image /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
Copier: Copied /private/tmp/dmg.oow2qH/Install VMware Tools.app to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg',
           'source_pkg': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware Tools.pkg'}}
PkgCopier: Copied /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware Tools.pkg to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'},
                                          'summary_text': 'The following packages were copied:'},
            'pkg_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'}}
PathDeleter
{'Input': {'path_list': (
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso"
)}}
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
{'Output': {}}
{'AUTOPKG_VERSION': u'1.4.1',
 u'CACHE_DIR': u'/Users/Shared/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 u'MUNKI_REPO': u'/Users/Shared/munki_repo',
 u'NAME': u'VMwareTools',
 'PARENT_RECIPES': [u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools',
 'RECIPE_DIR': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 u'RECIPE_OVERRIDE_DIRS': [u'/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
 u'RECIPE_REPOS': {u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {u'URL': u'https://github.com/autopkg/jessepeterson-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {u'URL': u'https://github.com/autopkg/justinrummel-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {u'URL': u'https://github.com/autopkg/recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {u'URL': u'https://github.com/autopkg/rtrouton-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {u'URL': u'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 u'RECIPE_REPO_DIR': u'/Users/Shared/AutoPkg/RecipeRepos',
 u'RECIPE_SEARCH_DIRS': [u'.',
                         u'~/Library/AutoPkg/Recipes',
                         u'/Library/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 u'archive_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
 u'destination_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
 'download_changed': False,
 'etag': '',
 u'filename': u'VMwareTools.zip.tar',
 'last_modified': '',
 u'path_list': (
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar",
    "/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso"
),
 'pathname': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar',
 'pkg_copier_summary_result': {'data': {'pkg_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'},
                               'summary_text': 'The following packages were copied:'},
 u'pkg_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg',
 'prefetch_filename': False,
 u'source': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso',
 u'source_path': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso/Install VMware Tools.app',
 u'source_pkg': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware Tools.pkg',
 u'target': u'/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso',
 'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
 'verbose': 4,
 'version': '11.5.1'}
Receipt written to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/receipts/VMwareTools-receipt-20191203-152146.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg
```

### AutoPkg 2.0b3:
```
./autopkg run -vvvv VMwareTools.pkg
Processing VMwareTools.pkg...
WARNING: VMwareTools.pkg is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'VMwareTools',
 'PARENT_RECIPES': ['/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 'verbose': 4}
VMwareGuestToolsURLProvider
{'Input': {}}
VMwareGuestToolsURLProvider: Base URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareGuestToolsURLProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml']
VMwareGuestToolsURLProvider: Searching for version series 11.5.0
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.1/15018442/core/metadata.xml.gz
('11.5.1', '15018442')
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.0/14634996/core/metadata.xml.gz
('11.5.0', '14634996')
VMwareGuestToolsURLProvider: Latest version URL suffix: fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: Version: 11.5.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
            'version': '11.5.1'}}
URLDownloader
{'Input': {'filename': 'VMwareTools.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar', '--fail', '--output', '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/tmpou4aqkka', '--header', 'If-None-Match: "d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"', '--header', 'If-Modified-Since: Tue, 05 Nov 2019 05:58:32 GMT']
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar
{'Output': {'pathname': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar'}}
Unarchiver: Guessed archive format 'tar' from filename VMwareTools.zip.tar
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
           'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools'}}
Unarchiver: Guessed archive format 'zip' from filename com.vmware.fusion.zip
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools
{'Output': {}}
FileMover
{'Input': {'source': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware '
                     'Fusion.app/Contents/Library/isoimages/darwin.iso',
           'target': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso'}}
FileMover: File /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso moved to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
           'source_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso/Install '
                          'VMware Tools.app'}}
Copier: Parsed dmg results: dmg_path: /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso, dmg: .iso/, dmg_source_path: Install VMware Tools.app
Copier: Mounted disk image /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
Copier: Copied /private/tmp/dmg.N6q6Oc/Install VMware Tools.app to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg',
           'source_pkg': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware '
                         'Tools.pkg'}}
PkgCopier: Copied /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware Tools.pkg to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'}}
PathDeleter
{'Input': {'path_list': ['/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso']}}
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso
{'Output': {}}
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'VMwareTools',
 'PARENT_RECIPES': ['/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 'archive_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
 'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
 'download_changed': False,
 'etag': '',
 'filename': 'VMwareTools.zip.tar',
 'last_modified': '',
 'path_list': ['/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-untar',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso'],
 'pathname': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/downloads/VMwareTools.zip.tar',
 'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg'},
                               'summary_text': 'The following packages were '
                                               'copied:'},
 'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg',
 'prefetch_filename': False,
 'source': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools/payload/VMware '
           'Fusion.app/Contents/Library/isoimages/darwin.iso',
 'source_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso/Install '
                'VMware Tools.app',
 'source_pkg': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-app/Contents/Resources/VMware '
               'Tools.pkg',
 'target': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools.iso',
 'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
 'verbose': 4,
 'version': '11.5.1'}
Receipt written to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/receipts/VMwareTools-receipt-20191203-151730.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/Shared/AutoPkg/Cache/com.github.rtrouton.pkg.VMwareTools/VMwareTools-11.5.1.pkg
```