### PR TITLE
Adding VMwareTools.munki recipe

### DIFF
--- a/VMware-Tools/VMwareTools.munki.recipe
+++ b/VMware-Tools/VMwareTools.munki.recipe
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>Downloads VMware Darwin ISO, extracts package, imports into Munki</string>
+		<key>Identifier</key>
+		<string>com.github.rtrouton.munki.VMwareTools</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>VMwareTools</string>
+			<key>MUNKI_REPO_SUBDIR</key>
+			<string>drivers</string>
+			<key>MUNKI_CATEGORY</key>
+			<string>Virtualization</string>
+			<key>pkginfo</key>
+			<dict>
+				<key>name</key>
+				<string>%NAME%</string>
+				<key>category</key>
+				<string>%MUNKI_CATEGORY%</string>
+				<key>display_name</key>
+				<string>VMware Tools</string>
+				<key>description</key>
+				<string>With the VMware Tools SVGA driver installed, Workstation supports significantly faster graphics performance.
+
+The VMware Tools package provides support required for shared folders and for drag and drop operations.
+
+Other tools in the package support synchronization of time in the guest operating system with time on the host, automatic grabbing and releasing of the mouse cursor, copying and pasting between guest and host, and improved mouse performance in some guest operating systems.</string>
+				<key>developer</key>
+				<string>VMware</string>
+				<key>catalogs</key>
+				<array>
+					<string>testing</string>
+				</array>
+				<key>minimum_os_version</key>
+				<string>10.11</string>
+			</dict>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>1.4</string>
+		<key>ParentRecipe</key>
+		<string>com.github.rtrouton.pkg.VMwareTools</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>MunkiImporter</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+					<key>repo_subdirectory</key>
+					<string>%MUNKI_REPO_SUBDIR%</string>
+				</dict>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/VMware-Tools/VMwareTools.pkg.recipe
+++ b/VMware-Tools/VMwareTools.pkg.recipe
@@ -39,6 +39,21 @@
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_path</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                    <key>expected_authority_names</key>
+                    <array>
+                        <string>Developer ID Installer: VMware, Inc. (EG7KH642X6)</string>
+                        <string>Developer ID Certification Authority</string>
+                        <string>Apple Root CA</string>
+                    </array>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>PathDeleter</string>
                 <key>Arguments</key>
                 <dict>


### PR DESCRIPTION
Also adding CodeSignatureVerification to .pkg recipe.

AutoPkg output:
```
autopkg run -vvvv VMwareTools.munki                       
Processing VMwareTools.munki...
WARNING: VMwareTools.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'MUNKI_CATEGORY': 'Virtualization',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'MUNKI_REPO_SUBDIR': 'drivers',
 'NAME': 'VMwareTools',
 'PARENT_RECIPES': ['/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
                    '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.munki.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 'pkginfo': {'catalogs': ['testing'],
             'category': 'Virtualization',
             'description': 'With the VMware Tools SVGA driver installed, '
                            'Workstation supports significantly faster '
                            'graphics performance.\n'
                            '\n'
                            'The VMware Tools package provides support '
                            'required for shared folders and for drag and drop '
                            'operations.\n'
                            '\n'
                            'Other tools in the package support '
                            'synchronization of time in the guest operating '
                            'system with time on the host, automatic grabbing '
                            'and releasing of the mouse cursor, copying and '
                            'pasting between guest and host, and improved '
                            'mouse performance in some guest operating '
                            'systems.',
             'developer': 'VMware',
             'display_name': 'VMware Tools',
             'minimum_os_version': '10.11',
             'name': 'VMwareTools'},
 'verbose': 4}
VMwareGuestToolsURLProvider
{'Input': {}}
VMwareGuestToolsURLProvider: Base URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareGuestToolsURLProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml']
VMwareGuestToolsURLProvider: Searching for version series 11.5.0
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.1/15018442/core/metadata.xml.gz
('11.5.1', '15018442')
VMwareGuestToolsURLProvider: Found version: 11.5.0 with URL: fusion/11.5.0/14634996/core/metadata.xml.gz
('11.5.0', '14634996')
VMwareGuestToolsURLProvider: Latest version URL suffix: fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: Version: 11.5.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
            'version': '11.5.1'}}
URLDownloader
{'Input': {'filename': 'VMwareTools.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar', '--fail', '--output', '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/downloads/tmpgvm5b2w_', '--header', 'If-None-Match: "d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"', '--header', 'If-Modified-Since: Tue, 05 Nov 2019 05:58:32 GMT']
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/downloads/VMwareTools.zip.tar
{'Output': {'pathname': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/downloads/VMwareTools.zip.tar'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar'}}
Unarchiver: Guessed archive format 'tar' from filename VMwareTools.zip.tar
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/downloads/VMwareTools.zip.tar to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
           'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools'}}
Unarchiver: Guessed archive format 'zip' from filename com.vmware.fusion.zip
Unarchiver: Unarchived /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools
{'Output': {}}
FileMover
{'Input': {'source': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools/payload/VMware '
                     'Fusion.app/Contents/Library/isoimages/darwin.iso',
           'target': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso'}}
FileMover: File /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso moved to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app',
           'source_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso/Install '
                          'VMware Tools.app'}}
Copier: Parsed dmg results: dmg_path: /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso, dmg: .iso/, dmg_source_path: Install VMware Tools.app
Copier: Mounted disk image /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso
Copier: Copied /private/tmp/dmg.vxJ40M/Install VMware Tools.app to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg',
           'source_pkg': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app/Contents/Resources/VMware '
                         'Tools.pkg'}}
PkgCopier: Copied /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app/Contents/Resources/VMware Tools.pkg to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg'}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: VMware, Inc. '
                                        '(EG7KH642X6)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "VMwareTools-11.5.1.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: VMware, Inc. (EG7KH642X6)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            3E 89 13 36 B2 1F CE D6 28 7E 97 16 51 35 F7 F7 9A AD 87 50 D2 44 
CodeSignatureVerifier:            86 DD AC 5A 96 28 4B 45 2D 26
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PathDeleter
{'Input': {'path_list': ['/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar',
                         '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso']}}
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar
PathDeleter: Deleted /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Virtualization',
                       'description': 'With the VMware Tools SVGA driver '
                                      'installed, Workstation supports '
                                      'significantly faster graphics '
                                      'performance.\n'
                                      '\n'
                                      'The VMware Tools package provides '
                                      'support required for shared folders and '
                                      'for drag and drop operations.\n'
                                      '\n'
                                      'Other tools in the package support '
                                      'synchronization of time in the guest '
                                      'operating system with time on the host, '
                                      'automatic grabbing and releasing of the '
                                      'mouse cursor, copying and pasting '
                                      'between guest and host, and improved '
                                      'mouse performance in some guest '
                                      'operating systems.',
                       'developer': 'VMware',
                       'display_name': 'VMware Tools',
                       'minimum_os_version': '10.11',
                       'name': 'VMwareTools'},
           'repo_subdirectory': 'drivers'}}
MunkiImporter: Copied pkginfo to /Users/Shared/munki_repo/pkgsinfo/drivers/VMwareTools-11.0.0.plist
MunkiImporter: Copied pkg to /Users/Shared/munki_repo/pkgs/drivers/VMwareTools-11.5.1-11.0.0.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'name': 'VMwareTools',
                                                       'pkg_repo_path': 'drivers/VMwareTools-11.5.1-11.0.0.pkg',
                                                       'pkginfo_path': 'drivers/VMwareTools-11.0.0.plist',
                                                       'version': '11.0.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'RestartAction': 'RequireRestart',
                           '_metadata': {'created_by': 'nmcspadden',
                                         'creation_date': datetime.datetime(2019, 12, 4, 18, 41, 19),
                                         'munki_version': '4.0.0.3881',
                                         'os_version': '10.15.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Virtualization',
                           'description': 'With the VMware Tools SVGA driver '
                                          'installed, Workstation supports '
                                          'significantly faster graphics '
                                          'performance.\n'
                                          '\n'
                                          'The VMware Tools package provides '
                                          'support required for shared folders '
                                          'and for drag and drop operations.\n'
                                          '\n'
                                          'Other tools in the package support '
                                          'synchronization of time in the '
                                          'guest operating system with time on '
                                          'the host, automatic grabbing and '
                                          'releasing of the mouse cursor, '
                                          'copying and pasting between guest '
                                          'and host, and improved mouse '
                                          'performance in some guest operating '
                                          'systems.',
                           'developer': 'VMware',
                           'display_name': 'VMware Tools',
                           'installed_size': 7425,
                           'installer_item_hash': '5f7049220eee7e888010b5d1b4e179457f488e809e7a28258517323ba4eb492a',
                           'installer_item_location': 'drivers/VMwareTools-11.5.1-11.0.0.pkg',
                           'installer_item_size': 2518,
                           'minimum_os_version': '10.11',
                           'name': 'VMwareTools',
                           'receipts': [{'installed_size': 7425,
                                         'packageid': 'com.vmware.tools.macos.pkg.files',
                                         'version': '11.0.0'}],
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '11.0.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/drivers/VMwareTools-11.5.1-11.0.0.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/drivers/VMwareTools-11.0.0.plist'}}
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKI_CATEGORY': 'Virtualization',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'MUNKI_REPO_SUBDIR': 'drivers',
 'NAME': 'VMwareTools',
 'PARENT_RECIPES': ['/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.pkg.recipe',
                    '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools/VMwareTools.munki.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/VMware-Tools'],
 'archive_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
 'destination_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app',
 'download_changed': False,
 'etag': '',
 'expected_authority_names': ['Developer ID Installer: VMware, Inc. '
                              '(EG7KH642X6)',
                              'Developer ID Certification Authority',
                              'Apple Root CA'],
 'filename': 'VMwareTools.zip.tar',
 'input_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg',
 'last_modified': '',
 'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                            'name': 'VMwareTools',
                                            'pkg_repo_path': 'drivers/VMwareTools-11.5.1-11.0.0.pkg',
                                            'pkginfo_path': 'drivers/VMwareTools-11.0.0.plist',
                                            'version': '11.0.0'},
                                   'report_fields': ['name',
                                                     'version',
                                                     'catalogs',
                                                     'pkginfo_path',
                                                     'pkg_repo_path'],
                                   'summary_text': 'The following new items '
                                                   'were imported into Munki:'},
 'munki_info': {'RestartAction': 'RequireRestart',
                '_metadata': {'created_by': 'nmcspadden',
                              'creation_date': datetime.datetime(2019, 12, 4, 18, 41, 19),
                              'munki_version': '4.0.0.3881',
                              'os_version': '10.15.1'},
                'autoremove': False,
                'catalogs': ['testing'],
                'category': 'Virtualization',
                'description': 'With the VMware Tools SVGA driver installed, '
                               'Workstation supports significantly faster '
                               'graphics performance.\n'
                               '\n'
                               'The VMware Tools package provides support '
                               'required for shared folders and for drag and '
                               'drop operations.\n'
                               '\n'
                               'Other tools in the package support '
                               'synchronization of time in the guest operating '
                               'system with time on the host, automatic '
                               'grabbing and releasing of the mouse cursor, '
                               'copying and pasting between guest and host, '
                               'and improved mouse performance in some guest '
                               'operating systems.',
                'developer': 'VMware',
                'display_name': 'VMware Tools',
                'installed_size': 7425,
                'installer_item_hash': '5f7049220eee7e888010b5d1b4e179457f488e809e7a28258517323ba4eb492a',
                'installer_item_location': 'drivers/VMwareTools-11.5.1-11.0.0.pkg',
                'installer_item_size': 2518,
                'minimum_os_version': '10.11',
                'name': 'VMwareTools',
                'receipts': [{'installed_size': 7425,
                              'packageid': 'com.vmware.tools.macos.pkg.files',
                              'version': '11.0.0'}],
                'uninstall_method': 'removepackages',
                'uninstallable': True,
                'version': '11.0.0'},
 'munki_repo_changed': True,
 'path_list': ['/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-untar',
               '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso'],
 'pathname': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/downloads/VMwareTools.zip.tar',
 'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg'},
                               'summary_text': 'The following packages were '
                                               'copied:'},
 'pkg_path': '/Users/Shared/munki_repo/pkgs/drivers/VMwareTools-11.5.1-11.0.0.pkg',
 'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/drivers/VMwareTools-11.5.1-11.0.0.pkg',
 'pkginfo': {'catalogs': ['testing'],
             'category': 'Virtualization',
             'description': 'With the VMware Tools SVGA driver installed, '
                            'Workstation supports significantly faster '
                            'graphics performance.\n'
                            '\n'
                            'The VMware Tools package provides support '
                            'required for shared folders and for drag and drop '
                            'operations.\n'
                            '\n'
                            'Other tools in the package support '
                            'synchronization of time in the guest operating '
                            'system with time on the host, automatic grabbing '
                            'and releasing of the mouse cursor, copying and '
                            'pasting between guest and host, and improved '
                            'mouse performance in some guest operating '
                            'systems.',
             'developer': 'VMware',
             'display_name': 'VMware Tools',
             'minimum_os_version': '10.11',
             'name': 'VMwareTools'},
 'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/drivers/VMwareTools-11.0.0.plist',
 'prefetch_filename': False,
 'repo_subdirectory': 'drivers',
 'source': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools/payload/VMware '
           'Fusion.app/Contents/Library/isoimages/darwin.iso',
 'source_path': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso/Install '
                'VMware Tools.app',
 'source_pkg': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-app/Contents/Resources/VMware '
               'Tools.pkg',
 'target': '/Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools.iso',
 'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
 'verbose': 4,
 'version': '11.5.1'}
Receipt written to /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/receipts/VMwareTools-receipt-20191204-104119.plist

The following packages were copied:
    Pkg Path                                                                                  
    --------                                                                                  
    /Users/Shared/AutoPkg/Cache/com.github.rtrouton.munki.VMwareTools/VMwareTools-11.5.1.pkg  

The following new items were imported into Munki:
    Name         Version  Catalogs  Pkginfo Path                      Pkg Repo Path                          
    ----         -------  --------  ------------                      -------------                          
    VMwareTools  11.0.0   testing   drivers/VMwareTools-11.0.0.plist  drivers/VMwareTools-11.5.1-11.0.0.pkg  
```