### PR TITLE
Improved the scripts

### DIFF
--- a/EndNote/EndNoteX9.munki.recipe
+++ b/EndNote/EndNoteX9.munki.recipe
@@ -41,53 +41,49 @@
 			</array>
 			<key>postinstall_script</key>
 			<string>#!/bin/zsh
+DIR="EndNote CWYW Word 16.bundle"
+PATH_SRC="/Applications/EndNote X9/Cite While You Write/$DIR"
+PATH_DEST="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/"
 
-		DIR="EndNote CWYW Word 16.bundle"
-		PATH_SRC="/Applications/EndNote X9/Cite While You Write/$DIR"
-		PATH_DEST="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/"
-
-		if [ -d "$PATH_SRC" ]
-		then
-			echo "Copied $DIR to $PATH_DEST"
-		  cp -r "$PATH_SRC" "$PATH_DEST"
-		else
-		    echo "Error: Directory $PATH_DEST does not exists."
-		fi
-		</string>
+[[ -d "$PATH_DEST" ]] || mkdir -p "$PATH_DEST"
+if [ -d "$PATH_SRC" ]
+then
+    echo "Copying $DIR to $PATH_DEST"
+    cp -r "$PATH_SRC" "$PATH_DEST"
+else
+    echo "Error: Directory $PATH_DEST does not exists."
+fi
+			</string>
 			<key>postuninstall_script</key>
 			<string>#!/bin/zsh
+DIR="EndNote CWYW Word 16.bundle"
+PATH_DEST="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/$DIR"
 
-		DIR="EndNote CWYW Word 16.bundle"
-		PATH_DEST="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/$DIR"
-
-		if [ -d "$PATH_DEST" ]
-		then
-			echo "Removed $PATH_DEST"
-		  rm -r "$PATH_DEST"
-		else
-		    echo "Error: Directory $PATH_DEST does not exists."
-		fi
-		</string>
+if [ -d "$PATH_DEST" ]
+then
+    echo "Removing $PATH_DEST"
+    rm -r "$PATH_DEST"
+fi
+			</string>
 			<key>preinstall_script</key>
 			<string>#!/bin/zsh
+endnote_bundle_2008="/Applications/Microsoft Office 2008/Office/Startup/Word/EndNote CWYW Word 2008.bundle"
+endnote_bundle_2011="/Applications/Microsoft Office 2011/Office/Startup/Word/EndNote CWYW Word 2011.bundle"
+endnote_bundle_2016="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/EndNote CWYW Word 2016.bundle"
 
-		endnote_bundle_2008="/Applications/Microsoft Office 2008/Office/Startup/Word/EndNote CWYW Word 2008.bundle"
-		endnote_bundle_2011="/Applications/Microsoft Office 2011/Office/Startup/Word/EndNote CWYW Word 2011.bundle"
-		endnote_bundle_2016="/Library/Application Support/Microsoft/Office365/User Content.localized/Startup.localized/Word/EndNote CWYW Word 2016.bundle"
+bundles=("$endnote_bundle_2008" "$endnote_bundle_2011" "$endnote_bundle_2016")
 
-		bundles=("$endnote_bundle_2008" "$endnote_bundle_2011" "$endnote_bundle_2016")
-
-		for i in "$bundles"; do
-		  if [ -d "$i" ]
-		  then
-				echo "Removing old CWYW bundle $i"
-		    rm -r "$i"
-		  else
-		    echo "$i is not installed"
-		    echo "Proceeding with installation"
-		  fi
-		done
-		</string>
+for i in $bundles; do
+  if [ -d "$i" ]
+  then
+    echo "Removing old CWYW bundle $i"
+    rm -r "$i"
+  else
+    echo "$i is not installed"
+    echo "Proceeding with installation"
+  fi
+done
+			</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
- The script would fail if the underlying directory for microsoft office was not present - a case which could occur if microsoft word was not started before installing the endnote plugin. Corrected this.
- removed the double quotes from "bundles", since the loop could not execute correct thus the strings of the paths were concatenated together instead of resolving the if exists statement for each path separately. 