### PR TITLE
Additional input variables for Corretto recipes

### DIFF
--- a/AmazonCorettoJDK11/AmazonCorettoJDK11.download.recipe
+++ b/AmazonCorettoJDK11/AmazonCorettoJDK11.download.recipe
@@ -22,6 +22,8 @@
         <string>https://github.com/corretto/corretto-11/releases/latest</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;https.*?corretto.*?\.pkg)</string>
+        <key>VERSION_SEARCH_PATTERN</key>
+        <string>amazon-corretto-(?P&lt;version&gt;.*?)-macosx-x64.pkg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -55,7 +57,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
-                <string>amazon-corretto-(?P&lt;version&gt;.*?)-macosx-x64.pkg</string>
+                <string>%VERSION_SEARCH_PATTERN%</string>
             </dict>
         </dict>
         <dict>

--- a/AmazonCorettoJDK11/AmazonCorettoJDK11.pkg.recipe
+++ b/AmazonCorettoJDK11/AmazonCorettoJDK11.pkg.recipe
@@ -18,6 +18,8 @@
         <string>Java</string>
         <key>SOFTWARETYPE</key>
         <string>JDK</string>
+        <key>PKG_PREFIX</key>
+        <string>%VENDOR%_%DISTRIBUTION%_%SOFTWARETITLE%_%SOFTWARETYPE%_</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.rtrouton.download.amazoncorettojdk11</string>
@@ -33,7 +35,7 @@
                <key>source_pkg</key>
                <string>%pathname%</string>
                <key>pkg_path</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%_%DISTRIBUTION%_%SOFTWARETITLE%_%SOFTWARETYPE%_%version%.pkg</string>
+               <string>%RECIPE_CACHE_DIR%/%PKG_PREFIX%%version%.pkg</string>
             </dict>
          </dict>
       </array>

--- a/AmazonCorettoJDK8/AmazonCorettoJDK8.download.recipe
+++ b/AmazonCorettoJDK8/AmazonCorettoJDK8.download.recipe
@@ -22,6 +22,8 @@
         <string>https://github.com/corretto/corretto-8/releases/latest</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;https.*?corretto.*?\.pkg)</string>
+        <key>VERSION_SEARCH_PATTERN</key>
+        <string>amazon-corretto-(?P&lt;version&gt;.*?)-macosx-x64.pkg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -55,7 +57,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
-                <string>amazon-corretto-(?P&lt;version&gt;.*?)-macosx-x64.pkg</string>
+                <string>%VERSION_SEARCH_PATTERN%</string>
             </dict>
         </dict>
         <dict>

--- a/AmazonCorettoJDK8/AmazonCorettoJDK8.pkg.recipe
+++ b/AmazonCorettoJDK8/AmazonCorettoJDK8.pkg.recipe
@@ -18,6 +18,8 @@
         <string>Java</string>
         <key>SOFTWARETYPE</key>
         <string>JDK</string>
+        <key>PKG_PREFIX</key>
+        <string>%VENDOR%_%DISTRIBUTION%_%SOFTWARETITLE%_%SOFTWARETYPE%_</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.rtrouton.download.amazoncorettojdk8</string>
@@ -33,7 +35,7 @@
                <key>source_pkg</key>
                <string>%pathname%</string>
                <key>pkg_path</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%_%DISTRIBUTION%_%SOFTWARETITLE%_%SOFTWARETYPE%_%version%.pkg</string>
+               <string>%RECIPE_CACHE_DIR%/%PKG_PREFIX%%version%.pkg</string>
             </dict>
          </dict>
       </array>


### PR DESCRIPTION
I utilize Autopkg pretty heavily in my Splashbuddy and patching workflow, and I've identified an issue with the Amazon Corretto 11 recipe that I can't work around. With the current release of Corretto, your recipe results in a version string that is '11.0.6.10.1-2' which unfortunately, doesn't match any of the properties of the installed files, so I'm unable to make an extension attribute to compare if the installed version is the latest one.

My PR moves the parts of your recipes that control the output file name (Splashbuddy wants 'Product'-'Version'.pkg), and the version parsing into input variables, so for people like me, I can adjust them via an override, rather than having to maintain my own copy of the recipe.

There was a little funny business regarding the %version% substitution, which is why I left it in the process section. 