### PR TITLE
Update parent recipe for IntelliJ CE to DataJAR

### DIFF
--- a/IntelliJ-CE/IntelliJ-CE.pkg.recipe
+++ b/IntelliJ-CE/IntelliJ-CE.pkg.recipe
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.facebook.autopkg.download.intellij</string>
+    <string>com.github.dataJAR-recipes.download.intellijideace</string>
     <key>Process</key>
     <array>
         <dict>

--- a/IntelliJ-CE/README.md
+++ b/IntelliJ-CE/README.md
@@ -1,20 +1,9 @@
-Before using the **IntelliJ-CE** recipes, you will need to add Facebook's AutoPkg repo from GitHub. The reason for this is that the download recipe for **IntelliJ Community Edition** is available from there and referenced in the following recipe:
 
-`IntelliJ-CE.pkg`
-
-The `IntelliJ-CE.pkg` recipe is in turn referenced by these two other recipes:
-
+The `IntelliJ-CE.pkg` recipe is referenced by these two other recipes:
 
 `IntelliJ-CE.install`
 
 `IntelliJ-CE.jss`
 
 
-Facebook's AutoPkg repo is available from the following address:
-
-[https://github.com/facebook/Recipes-for-AutoPkg](https://github.com/facebook/Recipes-for-AutoPkg)
-
-To add this repo to AutoPkg, please run the following command:
-
-`autopkg repo-add https://github.com/facebook/Recipes-for-AutoPkg`
 


### PR DESCRIPTION
With Facebook [deprecating the IntelliJ CE recipe](https://github.com/facebook/Recipes-for-AutoPkg/commit/be4169aaa33df2717dd86b43355ea5daa7d45387) move the parent to dataJAR-recipes.download.intellijideace.