### PR TITLE
Update version key

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.pkg.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.pkg.recipe
@@ -58,7 +58,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Teams.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>


### PR DESCRIPTION
Jamf reads the CFBundleVersion to report the application version instead of the standard CFBundleShortVersionString. Updated the variable to report and record the correct version to avoid needing an EA to report the version.