### PR TITLE
Added missing groups array for JSS recipe

### DIFF
--- a/JSS/MicrosoftOffice365BusinessProSuite.jss.recipe
+++ b/JSS/MicrosoftOffice365BusinessProSuite.jss.recipe
@@ -46,6 +46,17 @@
                     <string>%ICON%</string>
                     <key>self_service_description</key>
                     <string>%DESCRIPTION%</string>
+                    <key>groups</key>
+                    <array>
+                        <dict>
+                            <key>name</key>
+                            <string>%GROUP_NAME%</string>
+                            <key>smart</key>
+                            <true/>
+                            <key>template_path</key>
+                            <string>%GROUP_TEMPLATE%</string>
+                        </dict>
+                    </array>
                 </dict>
                 <key>Processor</key>
                 <string>JSSImporter</string>


### PR DESCRIPTION
The MicrosoftOffice365BusinessProSuite.jss.recipe file has a missing groups array which causes the smart group to fail to be created/updated in the JSS.