### PR TITLE
Re-adding MunkiPkginfoReceiptsEditor to Office365Suite recipe

### DIFF
--- a/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
+++ b/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
@@ -68,6 +68,10 @@ appends the version to the end of the filename, and imports into Munki.
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
It seems like the processor was removed without removing the Input that corresponds to it. I'm adding the processor back so that sub pkgs can be deselected easily.