### PR TITLE
Updated plist_version_key

### DIFF
--- a/MicrosoftEdge/MicrosoftEdge.pkg.recipe
+++ b/MicrosoftEdge/MicrosoftEdge.pkg.recipe
@@ -58,7 +58,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Edge.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>


### PR DESCRIPTION
The `plist_version_key` needs to be `CFBundleVersion` in order to report the same version that Jamf reports.