### PR TITLE
Deprecating Autopkg-Releases

### DIFF
--- a/AutoPkg-Release/AutoPkg-Release.download.recipe
+++ b/AutoPkg-Release/AutoPkg-Release.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release of AutoPkg from the AutoPkg release page on Github: https://github.com/autopkg/autopkg/releases</string>
+    <string>These recipes have moved into autopkg-recipes, and these are now deprecated.</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.download.AutoPkg-Release</string>
     <key>Input</key>
@@ -17,25 +17,12 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>GitHubReleasesInfoProvider</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
-                <key>github_repo</key>
-                <string>autopkg/autopkg</string>
+                <key>warning_message</key>
+                <string>These recipes have moved into autopkg-recipes, and the identifiers have changed. Please update your overrides!</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/AutoPkg-Release/AutoPkg-Release.install.recipe
+++ b/AutoPkg-Release/AutoPkg-Release.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of AutoPkg and installs it.</string>
+    <string>These recipes have moved into autopkg-recipes, and these are now deprecated.</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.install.AutoPkg-Release</string>
     <key>Input</key>
@@ -19,11 +19,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>Installer</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
+                <key>warning_message</key>
+                <string>These recipes have moved into autopkg-recipes, and the identifiers have changed. Please update your overrides!</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
These have been adopted into autopkg-recipes directly:
https://github.com/autopkg/recipes/commit/37bd7b9ce6bde650ac03839e71c5f095a0d19bc3