### PR TITLE
Adjust Fiji download pattern to accommodate changes in website

### DIFF
--- a/Fiji/Fiji.download.recipe
+++ b/Fiji/Fiji.download.recipe
@@ -17,17 +17,17 @@
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://imagej.nih.gov/ij/notes.html</string>
-				<key>re_pattern</key>
-				<string>Version (?P&lt;version&gt;[0-9a-z\.]*)</string>
-			</dict>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://imagej.nih.gov/ij/notes.html</string>
+                <key>re_pattern</key>
+                <string>Version (&amp;gt;)?(?P&lt;version&gt;[0-9a-z\.]*)</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Fiji/Fiji.download.recipe
+++ b/Fiji/Fiji.download.recipe
@@ -36,7 +36,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%-%version%.zip</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The NIH release notes site now has a greater-than character that prevents the pattern from matching.

<img width="770" alt="image" src="https://user-images.githubusercontent.com/7801391/94497889-6f1be080-01ad-11eb-9933-43452ca38c18.png">

This change adds an optional greater-than character (escaped once for HTML and once for the plist) to the pattern: `Version (&amp;gt;)?(?P&lt;version&gt;[0-9a-z\.]*)`

I've also added the detected version to the downloaded filename, in order to keep the current version separate in the cache from previous versions for archival purposes.