### PR TITLE
scrape to get the minor version

### DIFF
--- a/ImageJ/ImageJ.download.recipe
+++ b/ImageJ/ImageJ.download.recipe
@@ -12,7 +12,7 @@
         <string>ImageJ</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.9</string>
     <key>Process</key>
     <array>
         <dict>
@@ -20,6 +20,21 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
+                <key>result_output_var_name</key>
+                <string>version</string>
+                <key>url</key>
+                <string>https://imagej.nih.gov/ij/notes.html</string>
+                <key>re_pattern</key>
+                <string>&lt;u&gt;\s*([0-9a-z\\.]*)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>result_output_var_name</key>
+                <string>match</string>                
                 <key>url</key>
                 <string>https://imagej.nih.gov/ij/download.html</string>
                 <key>re_pattern</key>
@@ -34,7 +49,7 @@
                 <key>url</key>
                 <string>%match%</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%-%version%.zip</string>
             </dict>
         </dict>
         <dict>

--- a/ImageJ/ImageJ.pkg.recipe
+++ b/ImageJ/ImageJ.pkg.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>ImageJ</string>
+    <string>ImageJ</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.rtrouton.download.ImageJ</string>
@@ -42,20 +42,6 @@
                 <string>%pkgroot%/Applications</string>
                 <key>purge_destination</key>
                 <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%destination_path%/ImageJ.app</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleShortVersionString</key>
-                    <string>version</string>
-                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This change scrapes the notes page to get the proper version since the version in the app bundle does not include the minor version.  Addresses Issue #86

 