### PR TITLE
MicrosoftOffice365Suite.jss.recipe - Added 'groups' argument with variables

### DIFF
--- a/JSS/MicrosoftOffice365Suite.jss.recipe
+++ b/JSS/MicrosoftOffice365Suite.jss.recipe
@@ -42,6 +42,17 @@
                     <string>%POLICY_CATEGORY%</string>
                     <key>policy_template</key>
                     <string>%POLICY_TEMPLATE%</string>
+                    <key>groups</key>
+                    <array>
+                        <dict>
+                            <key>name</key>
+                            <string>%GROUP_NAME%</string>
+                            <key>smart</key>
+                            <true/>
+                            <key>template_path</key>
+                            <string>%GROUP_TEMPLATE%</string>
+                        </dict>
+                    </array>
                     <key>self_service_icon</key>
                     <string>%ICON%</string>
                     <key>self_service_description</key>


### PR DESCRIPTION
The MicrosoftOffice365Suite JSS recipe was not reading the GROUP_TEMPLATE key from my override, so I looked at the parent JSS recipe and noticed that the "groups" argument wasn't added. Once I added the change noted here, everything worked as expected. 

Let me know if you have any feedback or changes. Thanks for all your work!