### PR TITLE
Zscaler - Convert from downloader to package required

### DIFF
--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Processes the current release version of Zscaler for macOS. Must be downloaded from the private portal in the form https.*?Zscaler-osx.*?\.zip</string>
+    <string>Processes a pre-downloaded Zscaler installation zip for macOS. Provide the path to the zip to AutoPkg with the -p switch, for example: `autopkg run Zscaler.download -p ~/Downloads/Zscaler-1.2.3.zip`</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.download.zscaler</string>
     <key>Input</key>

--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Zscaler for macOS.</string>
+    <string>Processes the current release version of Zscaler for macOS. Must be downloaded from the private portal in the form https.*?Zscaler-osx.*?\.zip</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.download.zscaler</string>
     <key>Input</key>
@@ -12,42 +12,22 @@
 		<string>Zscaler</string>
 		<key>VENDOR</key>
 		<string>Zscaler</string>
-        <key>SEARCH_URL</key>
-        <string>https://www.zscaler.com/products/zscaler-app</string>
-        <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;https.*?Zscaler-osx.*?\.zip)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%url%</string>
-            </dict>
-        </dict>
+		<key>Processor</key>
+		<string>PackageRequired</string>
+	</dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
                 <key>archive_path</key>
-                <string>%pathname%</string>
+                <string>%PKG%</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%VENDOR%</string>
                 <key>purge_destination</key>

--- a/Zscaler/Zscaler.pkg.recipe
+++ b/Zscaler/Zscaler.pkg.recipe
@@ -76,7 +76,7 @@
             <key>Arguments</key>
             <dict>
                 <key>archive_path</key>
-                <string>%pathname%</string>
+                <string>%PKG%</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Scripts</string>
                 <key>purge_destination</key>


### PR DESCRIPTION
Zscaler no longer has a public download available. Converting to package required.