### PR TITLE
Make SEARCH_PATTERN non greedy

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -19,7 +19,7 @@
         <key>SEARCH_URL</key>
         <string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;http.*://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/osx10/ACCC.*?.dmg)</string>
+        <string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/osx10/ACCC.*?.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
Current search pattern is matching more than then expected url due to the first * and is returning :
 `https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_3_1/osx10/ACCCx5_3_1_470.dmg" disablelinktracking="false">Download&nbsp;</a><a href="https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_3_1/osx10/ACCCx5_3_1_470.dmg\`

adding ? to the first * to make it non greedy and match only the first url:

matches `https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_3_1/osx10/ACCCx5_3_1_470.dmg`