### PR TITLE
Identifier change for AdobeCreativeCloudInstaller

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -55,7 +55,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Install.app</string>
 				<key>requirement</key>
-				<string>identifier "com.adobe.Install" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JQ525L2MZD</string>
+				<string>identifier "com.adobe.cc.Install" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JQ525L2MZD</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Adobe seems to have changed the identifier with their new release builds of the Creative Cloud app.