### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/iMazingProfileEditor/iMazingProfileEditor.pkg.recipe
+++ b/iMazingProfileEditor/iMazingProfileEditor.pkg.recipe
@@ -17,7 +17,7 @@
         <key>SOFTWARETITLE2</key>
         <string>Editor</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.download.iMazingProfileEditor</string>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.