### PR TITLE
Read real CC version from XML

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -63,13 +63,33 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Install.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<key>source_path</key>
+				<string>%pathname%/packages/ApplicationInfo.xml</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/ApplicationInfo.xml</string>
+				<key>overwrite</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
-			<string>Versioner</string>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>xml_path</key>
+				<string>%RECIPE_CACHE_DIR%/ApplicationInfo.xml</string>
+				<key>elements</key>
+				<array>
+					<dict>
+						<key>xpath</key>
+						<string>version</string>
+						<key>text</key>
+						<string>version</string>
+					</dict>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.triti.SharedProcessors/XMLReader</string>
 		</dict>
 	</array>
 </dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.pkg.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.pkg.recipe
@@ -35,15 +35,35 @@
 			</dict>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Install.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<key>source_path</key>
+				<string>%pathname%/packages/ApplicationInfo.xml</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/ApplicationInfo.xml</string>
+				<key>overwrite</key>
+				<true/>
 			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>xml_path</key>
+				<string>%RECIPE_CACHE_DIR%/ApplicationInfo.xml</string>
+				<key>elements</key>
+				<array>
+					<dict>
+						<key>xpath</key>
+						<string>version</string>
+						<key>text</key>
+						<string>version</string>
+					</dict>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.triti.SharedProcessors/XMLReader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Adobe has given the Install.app its own versioning. 
To better reflect what version of Adobe CC we are installing use the Shared Processor XMLReader from triti to extract the version from the appended AppInfo XML