### PR TITLE
Fix parent recipe value in EndNote20.munki

### DIFF
--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -89,7 +89,7 @@ done
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.EndNote20</string>
+	<string>com.github.rtrouton.pkg.EndNote20</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR fixes the wrong value in the ParentRecipe key in the EndNote20.munki recipe, causing it to fail in an error.
After testing, it was shown that the recipe now runs as intended.