### PR TITLE
Remove receipt after uninstalling Privileges

### DIFF
--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -56,6 +56,7 @@ fi
 
 rm -rf "/Applications/Privileges.app"
 rm -rf "/Library/PrivilegedHelperTools/corp.sap.privileges.helper"
+pkgutil --forget com.sap.privileges
 </string>
 			<key>uninstallable</key>
 			<true/>


### PR DESCRIPTION
Current recipe employs an uninstall script that does not remove the install receipt, causing munki to believe app is still installed when it is not.

This PR adds the necessary receipt removal step.