### PR TITLE
Add option to select CF-version type

### DIFF
--- a/MicrosoftAutoUpdate/MicrosoftAutoUpdate.pkg.recipe
+++ b/MicrosoftAutoUpdate/MicrosoftAutoUpdate.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>AutoUpdate</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -49,7 +51,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft AutoUpdate.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftDefenderATP/MicrosoftDefenderATP.pkg.recipe
+++ b/MicrosoftDefenderATP/MicrosoftDefenderATP.pkg.recipe
@@ -16,6 +16,8 @@
          <string>Defender</string>
          <key>SOFTWARETYPE</key>
          <string>ATP</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleShortVersionString</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -60,7 +62,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Defender ATP.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftEdge/MicrosoftEdge.pkg.recipe
+++ b/MicrosoftEdge/MicrosoftEdge.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Edge</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleShortVersionString</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Edge.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftExcel365/MicrosoftExcel365.pkg.recipe
+++ b/MicrosoftExcel365/MicrosoftExcel365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Excel</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Excel.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftIntuneCompanyPortal/MicrosoftIntuneCompanyPortal.pkg.recipe
+++ b/MicrosoftIntuneCompanyPortal/MicrosoftIntuneCompanyPortal.pkg.recipe
@@ -18,6 +18,8 @@
          <string>Company</string>
          <key>SOFTWARETITLE3</key>
          <string>Portal</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleShortVersionString</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -53,7 +55,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Applications/Company Portal.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftOneDrive/MicrosoftOneDrive.pkg.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.pkg.recipe
@@ -1,82 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the current standalone Microsoft OneDrive installer, extracts version information and renames the installer package.</string>
-	<key>Identifier</key>
-	<string>com.github.rtrouton.pkg.microsoftonedrive</string>
-      <key>Input</key>
-      <dict>
-         <key>NAME</key>
-         <string>Microsoft OneDrive</string>
-         <key>VENDOR</key>
-         <string>Microsoft</string>
-         <key>SOFTWARETITLE</key>
-         <string>OneDrive</string>
-      </dict>
-	<key>MinimumVersion</key>
-	<string>0.6.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.microsoftonedrive</string>
-	<key>Process</key>
-	<array>
+    <dict>
+        <key>Description</key>
+        <string>Downloads the current standalone Microsoft OneDrive installer, extracts version information and renames the installer package.</string>
+        <key>Identifier</key>
+        <string>com.github.rtrouton.pkg.microsoftonedrive</string>
+        <key>Input</key>
         <dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
+            <key>NAME</key>
+            <string>Microsoft OneDrive</string>
+            <key>VENDOR</key>
+            <string>Microsoft</string>
+            <key>SOFTWARETITLE</key>
+            <string>OneDrive</string>
+            <key>VERSIONTYPE</key>
+            <string>CFBundleShortVersionString</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
+        <key>MinimumVersion</key>
+        <string>0.6.0</string>
+        <key>ParentRecipe</key>
+        <string>com.github.rtrouton.download.microsoftonedrive</string>
+        <key>Process</key>
+        <array>
             <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/%SOFTWARETITLE%.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>Processor</key>
+                <string>FlatPkgUnpacker</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>flat_pkg_path</key>
+                    <string>%pathname%</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </dict>
             </dict>
-        </dict>            
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/%SOFTWARETITLE%.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
+                <key>Processor</key>
+                <string>PkgPayloadUnpacker</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkg_payload_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/%SOFTWARETITLE%.pkg/Payload</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-            <key>Arguments</key>
             <dict>
-                <key>source_pkg</key>
-                <string>%pathname%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
+                <key>Processor</key>
+                <string>Versioner</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_plist_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/%SOFTWARETITLE%.app/Contents/Info.plist</string>
+                    <key>plist_version_key</key>
+                    <string>%VERSIONTYPE%</string>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-        <key>Arguments</key>
-        <dict>
-            <key>path_list</key>
-            <array>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
-            </array>
-        </dict>
-        <key>Processor</key>
-        <string>PathDeleter</string>
-	</dict>                   	      	
-	</array>
-</dict>
+            <dict>
+                <key>Processor</key>
+                <string>PkgCopier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>source_pkg</key>
+                    <string>%pathname%</string>
+                    <key>pkg_path</key>
+                    <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>path_list</key>
+                    <array>
+                        <string>%RECIPE_CACHE_DIR%/unpack</string>
+                        <string>%RECIPE_CACHE_DIR%/payload</string>
+                    </array>
+                </dict>
+                <key>Processor</key>
+                <string>PathDeleter</string>
+            </dict>
+        </array>
+    </dict>
 </plist>

--- a/MicrosoftOneNote365/MicrosoftOneNote365.pkg.recipe
+++ b/MicrosoftOneNote365/MicrosoftOneNote365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>OneNote</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft OneNote.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftOutlook365/MicrosoftOutlook365.pkg.recipe
+++ b/MicrosoftOutlook365/MicrosoftOutlook365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Outlook</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Outlook.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftPowerPoint365/MicrosoftPowerPoint365.pkg.recipe
+++ b/MicrosoftPowerPoint365/MicrosoftPowerPoint365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>PowerPoint</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft PowerPoint.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftSharepointBrowserPlugin/MicrosoftSharepointBrowserPlugin.pkg.recipe
+++ b/MicrosoftSharepointBrowserPlugin/MicrosoftSharepointBrowserPlugin.pkg.recipe
@@ -16,6 +16,8 @@
          <string>SharePoint</string>
          <key>SOFTWARETYPE</key>
          <string>Plugin</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -60,7 +62,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/SharePointBrowserPlugin.plugin/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftSkypeForBusiness365/MicrosoftSkypeForBusiness365.pkg.recipe
+++ b/MicrosoftSkypeForBusiness365/MicrosoftSkypeForBusiness365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Skype_For_Business</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftTeams/MicrosoftTeams.pkg.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Teams</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleShortVersionString</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Teams.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleShortVersionString</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftWord365/MicrosoftWord365.pkg.recipe
+++ b/MicrosoftWord365/MicrosoftWord365.pkg.recipe
@@ -14,6 +14,8 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Word</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleVersion</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -58,7 +60,7 @@
                <key>input_plist_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Word.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
-               <string>CFBundleVersion</string>
+               <string>%VERSIONTYPE%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/MicrosoftYammer/MicrosoftYammer.pkg.recipe
+++ b/MicrosoftYammer/MicrosoftYammer.pkg.recipe
@@ -14,6 +14,8 @@
             <string>Microsoft</string>
             <key>SOFTWARETITLE</key>
             <string>Yammer</string>
+            <key>VERSIONTYPE</key>
+            <string>CFBundleShortVersionString</string>
         </dict>
         <key>MinimumVersion</key>
         <string>1.0.0</string>
@@ -56,7 +58,7 @@
                     <key>input_plist_path</key>
                     <string>%pkgroot%/Applications/Yammer.app/Contents/Info.plist</string>
                     <key>plist_version_key</key>
-                    <string>CFBundleShortVersionString</string>
+                    <string>%VERSIONTYPE%</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
I have added the `VERSIONTYPE` Input key to each of the Microsoft pkg recipes, exactly as I previously did with the MicrosoftRemoteDesktop.pkg recipe. This allows recipe users to override the key used where it does not match their needs, for example Jamf Pro users who require `CFBundleVersion` due to this being used in the Jamf Pro inventory collection, or conversely Munki users switching Office apps to `CFBundleShortVersionString`, since this is used on the Mac itself to identify version.

MicrosoftOneDrive.pkg picked up some indentation inconsistencies when I saved the file, otherwise is exactly the same change as the others.