### PR TITLE
Update AdobeCreativeCloudInstaller.pkg.recipe

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.pkg.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.pkg.recipe
@@ -37,6 +37,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/Scripts</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>source_path</key>
 				<string>%pathname%/packages/ApplicationInfo.xml</string>
 				<key>destination_path</key>
@@ -71,35 +82,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/Install.app</string>
+				<string>%pathname%</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Scripts/Install.app</string>
-				<key>overwrite</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Copier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>source_path</key>
-				<string>%pathname%/packages</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Scripts/packages</string>
-				<key>overwrite</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Copier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>source_path</key>
-				<string>%pathname%/resources</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Scripts/resources</string>
+				<string>%RECIPE_CACHE_DIR%/Scripts/%VENDOR%%NAMEWITHOUTSPACES%-%version%.dmg</string>
 				<key>overwrite</key>
 				<true/>
 			</dict>
@@ -115,12 +100,27 @@
 				<string>0755</string>
 				<key>file_content</key>
 				<string>#!/bin/bash
-
+				
 # Determine working directory
-install_dir=$(dirname $0)
+installDir=$(dirname $0)
+dmg=("${installDir}"/*\.dmg)
 
-# Install the Creative Cloud  application using the Install binary's silent install mode
-"${install_dir}/Install.app/Contents/MacOS/Install" --mode=silent</string>
+# Mount the disk image to /Volumes
+mountResult=$(/usr/bin/hdiutil attach "${dmg}" -nobrowse -noverify -noautoopen)
+mountPoint=$(/bin/echo "${mountResult}" | /usr/bin/grep Volumes | /usr/bin/awk '{print substr($0, index($0,$3))}')
+
+# Install the software
+"${mountPoint}/Install.app/Contents/MacOS/Install" --mode=silent
+
+# Get the exit code so we can fail properly
+exitcode=$?
+
+# Unmount the disk image from /Volumes
+/usr/bin/hdiutil detach "${mountPoint}"
+
+# Exit according to whether the install succeeded or not
+exit "${exitcode}"
+</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Change to copy the DMG itself a resource and have the postinstall script mount it and run the installer within. This is because on Silicon, Adobe's installer app fails if it's copied directly as a package resource (it succeeds when run from within the source DMG).

Because we unmount the DMG at the end, we determine the exit code of Adobe's installer and use this as the postinstall exit code to ensure the package fails too if necessary (e.g. when installing on the wrong CPU architecture).