### PR TITLE
Remove launchctl (-w) flag in uninstall script

### DIFF
--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -48,7 +48,7 @@
             <string>#!/bin/bash
 
 if [[ -f "/Library/LaunchDaemons/corp.sap.privileges.helper.plist" ]]; then
-    launchctl unload -w "/Library/LaunchDaemons/corp.sap.privileges.helper.plist" 2&gt;/dev/null
+    launchctl unload "/Library/LaunchDaemons/corp.sap.privileges.helper.plist" 2&gt;/dev/null
     rm -rf "/Library/LaunchDaemons/corp.sap.privileges.helper.plist"
 fi
 


### PR DESCRIPTION
When uninstalling Privileges via the uninstall script, `launchctl unload -w /Library/LaunchDaemons/corp.sap.privileges.helper.plist` permanently disabled the helpertool's LaunchDaemon. If Privileges is reinstated via Munki or other means a `launchctl load -w /Library/LaunchDaemons/corp.sap.privileges.helper.plist` or `launchctl enable system/corp.sap.privileges.helper` and a reboot is necessary to enable the LaunchDaemon. 

Removing `-w` allows the uninstall script to unload the helper tool before removal, but does not disable a future install of the application.