### PR TITLE
Update EndNote20.munki.recipe

### DIFF
--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -93,14 +93,70 @@ done
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_path</key>
+				<string>%pathname%/Install EndNote 20.app/Contents/Resources/EndNote.zip</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/EndNote.zip</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%RECIPE_CACHE_DIR%/EndNote.zip</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/EndNote/EndNote 20.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+        </dict>
 	</array>
 </dict>
 </plist>

--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -154,6 +154,7 @@ done
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/Applications</string>
+					<string>%RECIPE_CACHE_DIR%/EndNote.zip</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
Amended to create an installs array of the .app on disk, and not the pkg receipt (which only comes from these recipes vs a manual install).

```
Processing /Users/ben/Git/other-recipes/rtrouton-recipes/EndNote/EndNote20.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/rtrouton-recipes/EndNote/EndNote20.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'EndNote 20.dmg',
           'url': 'https://download.endnote.com/downloads/20/EndNote20Installer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote '
                        '20.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote '
                               '20.dmg/Install EndNote '
                               '20.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Versioner: Found version 20.1.0.17060 in file /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg/Install EndNote 20.app/Contents/Info.plist
{'Output': {'version': '20.1.0.17060'}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote '
                         '20.dmg/Install EndNote 20.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.ThomsonResearchSoft.EndNote.Installer" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2Y4P62NL52")'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.eXHqwB/Install EndNote 20.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.eXHqwB/Install EndNote 20.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.eXHqwB/Install EndNote 20.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip',
           'source_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote '
                          '20.dmg/Install EndNote '
                          '20.app/Contents/Resources/EndNote.zip'}}
Copier: Parsed dmg results: dmg_path: /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg, dmg: .dmg/, dmg_source_path: Install EndNote 20.app/Contents/Resources/EndNote.zip
Copier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Copier: Copied /private/tmp/dmg.beC0Bp/Install EndNote 20.app/Contents/Resources/EndNote.zip to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip',
           'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename EndNote.zip
Unarchiver: Unarchived /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote/EndNote '
                               '20.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString',
           'skip_single_root_dir': False}}
Versioner: Found version 20.1.0.17060 in file /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote/EndNote 20.app/Contents/Info.plist
{'Output': {'version': '20.1.0.17060'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot/Applications/EndNote '
                               '20',
           'source_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote'}}
Copier: Parsed dmg results: dmg_path: /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote, dmg: , dmg_source_path:
Copier: Copied /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot/Applications/EndNote 20
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.endnote.EndNote20.pkg',
                           'pkgname': 'EndNote-20.1.0.17060',
                           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot',
                           'pkgtype': 'flat',
                           'version': '20.1.0.17060'}}}
PkgCreator: Package already exists at path /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote-20.1.0.17060.pkg.
PkgCreator: Existing package matches version and identifier, not building.
{'Output': {'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote-20.1.0.17060.pkg'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip',
           'source_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote '
                          '20.dmg/Install EndNote '
                          '20.app/Contents/Resources/EndNote.zip'}}
Copier: Parsed dmg results: dmg_path: /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg, dmg: .dmg/, dmg_source_path: Install EndNote 20.app/Contents/Resources/EndNote.zip
Copier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Copier: Copied /private/tmp/dmg.hCvpkg/Install EndNote 20.app/Contents/Resources/EndNote.zip to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip',
           'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename EndNote.zip
Unarchiver: Unarchived /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20',
           'installs_item_paths': ['/Applications/EndNote/EndNote 20.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/EndNote/EndNote 20.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote',
                                                 'CFBundleShortVersionString': '20.1.0.17060',
                                                 'CFBundleVersion': '2021.20.1.0.17060',
                                                 'minosversion': '10.10.0',
                                                 'path': '/Applications/EndNote/EndNote '
                                                         '20.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote',
                                                'CFBundleShortVersionString': '20.1.0.17060',
                                                'CFBundleVersion': '2021.20.1.0.17060',
                                                'minosversion': '10.10.0',
                                                'path': '/Applications/EndNote/EndNote '
                                                        '20.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Microsoft Word',
                                                 'EndNote 20'],
                       'catalogs': ['testing'],
                       'category': 'Reference',
                       'description': 'Bibliographic management app.',
                       'developer': 'Thomson Reuters',
                       'display_name': 'EndNote 20',
                       'minimum_os_version': '10.10.0',
                       'name': 'EndNote 20',
                       'postinstall_script': '#!/bin/zsh\n'
                                             'DIR="EndNote CWYW Word '
                                             '16.bundle"\n'
                                             'PATH_SRC="/Applications/EndNote '
                                             '20/Cite While You Write/$DIR"\n'
                                             'PATH_DEST="/Library/Application '
                                             'Support/Microsoft/Office365/User '
                                             'Content.localized/Startup.localized/Word/"\n'
                                             '\n'
                                             '[[ -d "$PATH_DEST" ]] || mkdir '
                                             '-p "$PATH_DEST"\n'
                                             'if [ -d "$PATH_SRC" ]\n'
                                             'then\n'
                                             '    echo "Copying $DIR to '
                                             '$PATH_DEST"\n'
                                             '    cp -r "$PATH_SRC" '
                                             '"$PATH_DEST"\n'
                                             'else\n'
                                             '    echo "Error: Directory '
                                             '$PATH_SRC does not exists."\n'
                                             'fi\n'
                                             '\t\t\t',
                       'postuninstall_script': '#!/bin/zsh\n'
                                               'DIR="EndNote CWYW Word '
                                               '16.bundle"\n'
                                               'PATH_DEST="/Library/Application '
                                               'Support/Microsoft/Office365/User '
                                               'Content.localized/Startup.localized/Word/$DIR"\n'
                                               '\n'
                                               'if [ -d "$PATH_DEST" ]\n'
                                               'then\n'
                                               '    echo "Removing '
                                               '$PATH_DEST"\n'
                                               '    rm -r "$PATH_DEST"\n'
                                               'fi\n'
                                               '\t\t\t',
                       'preinstall_script': '#!/bin/zsh\n'
                                            'endnote_bundle_2008="/Applications/Microsoft '
                                            'Office '
                                            '2008/Office/Startup/Word/EndNote '
                                            'CWYW Word 2008.bundle"\n'
                                            'endnote_bundle_2011="/Applications/Microsoft '
                                            'Office '
                                            '2011/Office/Startup/Word/EndNote '
                                            'CWYW Word 2011.bundle"\n'
                                            'endnote_bundle_2016="/Library/Application '
                                            'Support/Microsoft/Office365/User '
                                            'Content.localized/Startup.localized/Word/EndNote '
                                            'CWYW Word 2016.bundle"\n'
                                            '\n'
                                            'bundles=("$endnote_bundle_2008" '
                                            '"$endnote_bundle_2011" '
                                            '"$endnote_bundle_2016")\n'
                                            '\n'
                                            'for i in $bundles; do\n'
                                            '  if [ -d "$i" ]\n'
                                            '  then\n'
                                            '    echo "Removing old CWYW '
                                            'bundle $i"\n'
                                            '    rm -r "$i"\n'
                                            '  else\n'
                                            '    echo "$i is not installed"\n'
                                            '    echo "Proceeding with '
                                            'installation"\n'
                                            '  fi\n'
                                            'done\n'
                                            '\t\t\t',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote', 'CFBundleShortVersionString': '20.1.0.17060', 'CFBundleVersion': '2021.20.1.0.17060', 'minosversion': '10.10.0', 'path': '/Applications/EndNote/EndNote 20.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Microsoft Word',
                                                  'EndNote 20'],
                        'catalogs': ['testing'],
                        'category': 'Reference',
                        'description': 'Bibliographic management app.',
                        'developer': 'Thomson Reuters',
                        'display_name': 'EndNote 20',
                        'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote',
                                      'CFBundleShortVersionString': '20.1.0.17060',
                                      'CFBundleVersion': '2021.20.1.0.17060',
                                      'minosversion': '10.10.0',
                                      'path': '/Applications/EndNote/EndNote '
                                              '20.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.10.0',
                        'name': 'EndNote 20',
                        'postinstall_script': '#!/bin/zsh\n'
                                              'DIR="EndNote CWYW Word '
                                              '16.bundle"\n'
                                              'PATH_SRC="/Applications/EndNote '
                                              '20/Cite While You Write/$DIR"\n'
                                              'PATH_DEST="/Library/Application '
                                              'Support/Microsoft/Office365/User '
                                              'Content.localized/Startup.localized/Word/"\n'
                                              '\n'
                                              '[[ -d "$PATH_DEST" ]] || mkdir '
                                              '-p "$PATH_DEST"\n'
                                              'if [ -d "$PATH_SRC" ]\n'
                                              'then\n'
                                              '    echo "Copying $DIR to '
                                              '$PATH_DEST"\n'
                                              '    cp -r "$PATH_SRC" '
                                              '"$PATH_DEST"\n'
                                              'else\n'
                                              '    echo "Error: Directory '
                                              '$PATH_SRC does not exists."\n'
                                              'fi\n'
                                              '\t\t\t',
                        'postuninstall_script': '#!/bin/zsh\n'
                                                'DIR="EndNote CWYW Word '
                                                '16.bundle"\n'
                                                'PATH_DEST="/Library/Application '
                                                'Support/Microsoft/Office365/User '
                                                'Content.localized/Startup.localized/Word/$DIR"\n'
                                                '\n'
                                                'if [ -d "$PATH_DEST" ]\n'
                                                'then\n'
                                                '    echo "Removing '
                                                '$PATH_DEST"\n'
                                                '    rm -r "$PATH_DEST"\n'
                                                'fi\n'
                                                '\t\t\t',
                        'preinstall_script': '#!/bin/zsh\n'
                                             'endnote_bundle_2008="/Applications/Microsoft '
                                             'Office '
                                             '2008/Office/Startup/Word/EndNote '
                                             'CWYW Word 2008.bundle"\n'
                                             'endnote_bundle_2011="/Applications/Microsoft '
                                             'Office '
                                             '2011/Office/Startup/Word/EndNote '
                                             'CWYW Word 2011.bundle"\n'
                                             'endnote_bundle_2016="/Library/Application '
                                             'Support/Microsoft/Office365/User '
                                             'Content.localized/Startup.localized/Word/EndNote '
                                             'CWYW Word 2016.bundle"\n'
                                             '\n'
                                             'bundles=("$endnote_bundle_2008" '
                                             '"$endnote_bundle_2011" '
                                             '"$endnote_bundle_2016")\n'
                                             '\n'
                                             'for i in $bundles; do\n'
                                             '  if [ -d "$i" ]\n'
                                             '  then\n'
                                             '    echo "Removing old CWYW '
                                             'bundle $i"\n'
                                             '    rm -r "$i"\n'
                                             '  else\n'
                                             '    echo "$i is not installed"\n'
                                             '    echo "Proceeding with '
                                             'installation"\n'
                                             '  fi\n'
                                             'done\n'
                                             '\t\t\t',
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote-20.1.0.17060.pkg',
           'pkginfo': {'blocking_applications': ['Microsoft Word',
                                                 'EndNote 20'],
                       'catalogs': ['testing'],
                       'category': 'Reference',
                       'description': 'Bibliographic management app.',
                       'developer': 'Thomson Reuters',
                       'display_name': 'EndNote 20',
                       'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote',
                                     'CFBundleShortVersionString': '20.1.0.17060',
                                     'CFBundleVersion': '2021.20.1.0.17060',
                                     'minosversion': '10.10.0',
                                     'path': '/Applications/EndNote/EndNote '
                                             '20.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.10.0',
                       'name': 'EndNote 20',
                       'postinstall_script': '#!/bin/zsh\n'
                                             'DIR="EndNote CWYW Word '
                                             '16.bundle"\n'
                                             'PATH_SRC="/Applications/EndNote '
                                             '20/Cite While You Write/$DIR"\n'
                                             'PATH_DEST="/Library/Application '
                                             'Support/Microsoft/Office365/User '
                                             'Content.localized/Startup.localized/Word/"\n'
                                             '\n'
                                             '[[ -d "$PATH_DEST" ]] || mkdir '
                                             '-p "$PATH_DEST"\n'
                                             'if [ -d "$PATH_SRC" ]\n'
                                             'then\n'
                                             '    echo "Copying $DIR to '
                                             '$PATH_DEST"\n'
                                             '    cp -r "$PATH_SRC" '
                                             '"$PATH_DEST"\n'
                                             'else\n'
                                             '    echo "Error: Directory '
                                             '$PATH_SRC does not exists."\n'
                                             'fi\n'
                                             '\t\t\t',
                       'postuninstall_script': '#!/bin/zsh\n'
                                               'DIR="EndNote CWYW Word '
                                               '16.bundle"\n'
                                               'PATH_DEST="/Library/Application '
                                               'Support/Microsoft/Office365/User '
                                               'Content.localized/Startup.localized/Word/$DIR"\n'
                                               '\n'
                                               'if [ -d "$PATH_DEST" ]\n'
                                               'then\n'
                                               '    echo "Removing '
                                               '$PATH_DEST"\n'
                                               '    rm -r "$PATH_DEST"\n'
                                               'fi\n'
                                               '\t\t\t',
                       'preinstall_script': '#!/bin/zsh\n'
                                            'endnote_bundle_2008="/Applications/Microsoft '
                                            'Office '
                                            '2008/Office/Startup/Word/EndNote '
                                            'CWYW Word 2008.bundle"\n'
                                            'endnote_bundle_2011="/Applications/Microsoft '
                                            'Office '
                                            '2011/Office/Startup/Word/EndNote '
                                            'CWYW Word 2011.bundle"\n'
                                            'endnote_bundle_2016="/Library/Application '
                                            'Support/Microsoft/Office365/User '
                                            'Content.localized/Startup.localized/Word/EndNote '
                                            'CWYW Word 2016.bundle"\n'
                                            '\n'
                                            'bundles=("$endnote_bundle_2008" '
                                            '"$endnote_bundle_2011" '
                                            '"$endnote_bundle_2016")\n'
                                            '\n'
                                            'for i in $bundles; do\n'
                                            '  if [ -d "$i" ]\n'
                                            '  then\n'
                                            '    echo "Removing old CWYW '
                                            'bundle $i"\n'
                                            '    rm -r "$i"\n'
                                            '  else\n'
                                            '    echo "$i is not installed"\n'
                                            '    echo "Proceeding with '
                                            'installation"\n'
                                            '  fi\n'
                                            'done\n'
                                            '\t\t\t',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/EndNote 20',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/EndNote 20/EndNote 20-20.1.0.17060__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/EndNote 20/EndNote-20.1.0.17060__2.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'EndNote 20',
                                                       'pkg_repo_path': 'apps/EndNote '
                                                                        '20/EndNote-20.1.0.17060__2.pkg',
                                                       'pkginfo_path': 'apps/EndNote '
                                                                       '20/EndNote '
                                                                       '20-20.1.0.17060__2.plist',
                                                       'version': '20.1.0.17060'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 9, 8, 14, 10, 24),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Microsoft Word',
                                                     'EndNote 20'],
                           'catalogs': ['testing'],
                           'category': 'Reference',
                           'description': 'Bibliographic management app.',
                           'developer': 'Thomson Reuters',
                           'display_name': 'EndNote 20',
                           'installed_size': 467948,
                           'installer_item_hash': '9fb9307e17545ec5c0d72ef9608180b4c07627c8006dd9ec09c421222475fbe1',
                           'installer_item_location': 'apps/EndNote '
                                                      '20/EndNote-20.1.0.17060__2.pkg',
                           'installer_item_size': 81889,
                           'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote',
                                         'CFBundleShortVersionString': '20.1.0.17060',
                                         'CFBundleVersion': '2021.20.1.0.17060',
                                         'minosversion': '10.10.0',
                                         'path': '/Applications/EndNote/EndNote '
                                                 '20.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.10.0',
                           'name': 'EndNote 20',
                           'postinstall_script': '#!/bin/zsh\n'
                                                 'DIR="EndNote CWYW Word '
                                                 '16.bundle"\n'
                                                 'PATH_SRC="/Applications/EndNote '
                                                 '20/Cite While You '
                                                 'Write/$DIR"\n'
                                                 'PATH_DEST="/Library/Application '
                                                 'Support/Microsoft/Office365/User '
                                                 'Content.localized/Startup.localized/Word/"\n'
                                                 '\n'
                                                 '[[ -d "$PATH_DEST" ]] || '
                                                 'mkdir -p "$PATH_DEST"\n'
                                                 'if [ -d "$PATH_SRC" ]\n'
                                                 'then\n'
                                                 '    echo "Copying $DIR to '
                                                 '$PATH_DEST"\n'
                                                 '    cp -r "$PATH_SRC" '
                                                 '"$PATH_DEST"\n'
                                                 'else\n'
                                                 '    echo "Error: Directory '
                                                 '$PATH_SRC does not exists."\n'
                                                 'fi\n'
                                                 '\t\t\t',
                           'postuninstall_script': '#!/bin/zsh\n'
                                                   'DIR="EndNote CWYW Word '
                                                   '16.bundle"\n'
                                                   'PATH_DEST="/Library/Application '
                                                   'Support/Microsoft/Office365/User '
                                                   'Content.localized/Startup.localized/Word/$DIR"\n'
                                                   '\n'
                                                   'if [ -d "$PATH_DEST" ]\n'
                                                   'then\n'
                                                   '    echo "Removing '
                                                   '$PATH_DEST"\n'
                                                   '    rm -r "$PATH_DEST"\n'
                                                   'fi\n'
                                                   '\t\t\t',
                           'preinstall_script': '#!/bin/zsh\n'
                                                'endnote_bundle_2008="/Applications/Microsoft '
                                                'Office '
                                                '2008/Office/Startup/Word/EndNote '
                                                'CWYW Word 2008.bundle"\n'
                                                'endnote_bundle_2011="/Applications/Microsoft '
                                                'Office '
                                                '2011/Office/Startup/Word/EndNote '
                                                'CWYW Word 2011.bundle"\n'
                                                'endnote_bundle_2016="/Library/Application '
                                                'Support/Microsoft/Office365/User '
                                                'Content.localized/Startup.localized/Word/EndNote '
                                                'CWYW Word 2016.bundle"\n'
                                                '\n'
                                                'bundles=("$endnote_bundle_2008" '
                                                '"$endnote_bundle_2011" '
                                                '"$endnote_bundle_2016")\n'
                                                '\n'
                                                'for i in $bundles; do\n'
                                                '  if [ -d "$i" ]\n'
                                                '  then\n'
                                                '    echo "Removing old CWYW '
                                                'bundle $i"\n'
                                                '    rm -r "$i"\n'
                                                '  else\n'
                                                '    echo "$i is not '
                                                'installed"\n'
                                                '    echo "Proceeding with '
                                                'installation"\n'
                                                '  fi\n'
                                                'done\n'
                                                '\t\t\t',
                           'receipts': [{'installed_size': 467948,
                                         'packageid': 'com.endnote.EndNote20.pkg',
                                         'version': '20.1.0.17060'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '20.1.0.17060'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/EndNote '
                             '20/EndNote-20.1.0.17060__2.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/EndNote '
                                 '20/EndNote 20-20.1.0.17060__2.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/receipts/EndNote20.munki-receipt-20210908-151026.plist

The following new items were imported into Munki:
    Name        Version       Catalogs  Pkginfo Path                                      Pkg Repo Path                                Icon Repo Path
    ----        -------       --------  ------------                                      -------------                                --------------
    EndNote 20  20.1.0.17060  testing   apps/EndNote 20/EndNote 20-20.1.0.17060__2.plist  apps/EndNote 20/EndNote-20.1.0.17060__2.pkg
```