### PR TITLE
Set minimum_os_version to 10.14.0

### DIFF
--- a/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
@@ -31,7 +31,7 @@
             <key>name</key>
             <string>%NAME%</string>
             <key>minimum_os_version</key>
-            <string>10.12.0</string>
+            <string>10.14.0</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
According to [MS](https://support.microsoft.com/en-us/office/onedrive-system-requirements-cc0cb2b8-f446-445c-9b52-d3c2627d681e), the minimum_os_version is now 10.14.0.