### PR TITLE
Enhanced Munki recipes for Office apps

### DIFF
--- a/MicrosoftExcel365/MicrosoftExcel365.munki.recipe
+++ b/MicrosoftExcel365/MicrosoftExcel365.munki.recipe
@@ -14,6 +14,12 @@
         <string>apps/msoffice</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Microsoft AutoUpdate</string>
+                <string>Microsoft Error Reporting</string>
+                <string>Microsoft Excel</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -24,14 +30,32 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftexcel365</string>
+    <string>com.github.rtrouton.pkg.microsoftexcel365</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftExcel365/MicrosoftExcel365.pkg.recipe
+++ b/MicrosoftExcel365/MicrosoftExcel365.pkg.recipe
@@ -66,6 +66,20 @@
             <string>Versioner</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>info_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Excel.app/Contents/Info.plist</string>
+               <key>plist_keys</key>
+               <dict>
+                  <key>LSMinimumSystemVersion</key>
+                  <string>minimum_os_version</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
@@ -75,6 +89,46 @@
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
             </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pkgroot</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>pkgdirs</key>
+               <dict>
+                  <key>Applications</key>
+                  <string>0775</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>source</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Excel.app</string>
+               <key>target</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root/Applications/Microsoft Excel.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>installs_item_paths</key>
+               <array>
+                  <string>/Applications/Microsoft Excel.app</string>
+               </array>
+               <key>faux_root</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>version_comparison_key</key>
+               <string>%VERSIONTYPE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
          </dict>
          <dict>
             <key>Processor</key>

--- a/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
@@ -6,8 +6,6 @@
     <string>Downloads the latest Microsoft OneDrive installer and imports into Munki.</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.munki.microsoftonedrive</string>
-    <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftonedrive</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -21,23 +19,43 @@
                 <string>testing</string>
             </array>
             <key>description</key>
-            <string>Microsoft Onedrive</string>
+            <string>Microsoft OneDrive</string>
             <key>display_name</key>
-            <string>Microsoft Onedrive</string>
+            <string>Microsoft OneDrive</string>
             <key>developer</key>
             <string>Microsoft</string>
             <key>category</key>
             <string>Productivity</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>minimum_os_version</key>
-            <string>10.14.0</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.rtrouton.pkg.microsoftonedrive</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
@@ -28,10 +28,10 @@
             <string>Productivity</string>
             <key>name</key>
             <string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>unattended_uninstall</key>
-			<true/>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/MicrosoftOneDrive/MicrosoftOneDrive.pkg.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.pkg.recipe
@@ -57,6 +57,20 @@
                 </dict>
             </dict>
             <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>info_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/%SOFTWARETITLE%.app/Contents/Info.plist</string>
+                    <key>plist_keys</key>
+                    <dict>
+                        <key>LSMinimumSystemVersion</key>
+                        <string>minimum_os_version</string>
+                    </dict>
+                </dict>
+                <key>Processor</key>
+                <string>PlistReader</string>
+            </dict>
+            <dict>
                 <key>Processor</key>
                 <string>PkgCopier</string>
                 <key>Arguments</key>
@@ -66,6 +80,46 @@
                     <key>pkg_path</key>
                     <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
                 </dict>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkgroot</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/faux_root</string>
+                    <key>pkgdirs</key>
+                    <dict>
+                        <key>Applications</key>
+                        <string>0775</string>
+                    </dict>
+                </dict>
+                <key>Processor</key>
+                <string>PkgRootCreator</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>source</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/OneDrive.app</string>
+                    <key>target</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/faux_root/Applications/OneDrive.app</string>
+                </dict>
+                <key>Processor</key>
+                <string>FileMover</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>installs_item_paths</key>
+                    <array>
+                        <string>/Applications/OneDrive.app</string>
+                    </array>
+                    <key>faux_root</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/faux_root</string>
+                    <key>version_comparison_key</key>
+                    <string>%VERSIONTYPE%</string>
+                </dict>
+                <key>Processor</key>
+                <string>MunkiInstallsItemsCreator</string>
             </dict>
             <dict>
                 <key>Arguments</key>

--- a/MicrosoftOneNote365/MicrosoftOneNote365.munki.recipe
+++ b/MicrosoftOneNote365/MicrosoftOneNote365.munki.recipe
@@ -14,6 +14,12 @@
         <string>apps/msoffice</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Microsoft AutoUpdate</string>
+                <string>Microsoft Error Reporting</string>
+                <string>Microsoft OneNote</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -24,14 +30,32 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftonenote365</string>
+    <string>com.github.rtrouton.pkg.microsoftonenote365</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftOneNote365/MicrosoftOneNote365.pkg.recipe
+++ b/MicrosoftOneNote365/MicrosoftOneNote365.pkg.recipe
@@ -66,6 +66,20 @@
             <string>Versioner</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>info_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft OneNote.app/Contents/Info.plist</string>
+               <key>plist_keys</key>
+               <dict>
+                  <key>LSMinimumSystemVersion</key>
+                  <string>minimum_os_version</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
@@ -75,6 +89,46 @@
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
             </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pkgroot</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>pkgdirs</key>
+               <dict>
+                  <key>Applications</key>
+                  <string>0775</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>source</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft OneNote.app</string>
+               <key>target</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root/Applications/Microsoft OneNote.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>installs_item_paths</key>
+               <array>
+                  <string>/Applications/Microsoft OneNote.app</string>
+               </array>
+               <key>faux_root</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>version_comparison_key</key>
+               <string>%VERSIONTYPE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
          </dict>
          <dict>
             <key>Processor</key>

--- a/MicrosoftOutlook365/MicrosoftOutlook365.munki.recipe
+++ b/MicrosoftOutlook365/MicrosoftOutlook365.munki.recipe
@@ -14,6 +14,12 @@
         <string>apps/msoffice</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Microsoft AutoUpdate</string>
+                <string>Microsoft Error Reporting</string>
+                <string>Microsoft Outlook</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -24,14 +30,32 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftoutlook365</string>
+    <string>com.github.rtrouton.pkg.microsoftoutlook365</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftOutlook365/MicrosoftOutlook365.pkg.recipe
+++ b/MicrosoftOutlook365/MicrosoftOutlook365.pkg.recipe
@@ -66,6 +66,20 @@
             <string>Versioner</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>info_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Outlook.app/Contents/Info.plist</string>
+               <key>plist_keys</key>
+               <dict>
+                  <key>LSMinimumSystemVersion</key>
+                  <string>minimum_os_version</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
@@ -75,6 +89,46 @@
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
             </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pkgroot</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>pkgdirs</key>
+               <dict>
+                  <key>Applications</key>
+                  <string>0775</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>source</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Outlook.app</string>
+               <key>target</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root/Applications/Microsoft Outlook.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>installs_item_paths</key>
+               <array>
+                  <string>/Applications/Microsoft Outlook.app</string>
+               </array>
+               <key>faux_root</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>version_comparison_key</key>
+               <string>%VERSIONTYPE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
          </dict>
          <dict>
             <key>Processor</key>

--- a/MicrosoftPowerPoint365/MicrosoftPowerPoint365.pkg.recipe
+++ b/MicrosoftPowerPoint365/MicrosoftPowerPoint365.pkg.recipe
@@ -66,6 +66,20 @@
             <string>Versioner</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>info_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft PowerPoint.app/Contents/Info.plist</string>
+               <key>plist_keys</key>
+               <dict>
+                  <key>LSMinimumSystemVersion</key>
+                  <string>minimum_os_version</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
@@ -75,6 +89,46 @@
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
             </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pkgroot</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>pkgdirs</key>
+               <dict>
+                  <key>Applications</key>
+                  <string>0775</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>source</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft PowerPoint.app</string>
+               <key>target</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root/Applications/Microsoft PowerPoint.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>installs_item_paths</key>
+               <array>
+                  <string>/Applications/Microsoft PowerPoint.app</string>
+               </array>
+               <key>faux_root</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>version_comparison_key</key>
+               <string>%VERSIONTYPE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
          </dict>
          <dict>
             <key>Processor</key>

--- a/MicrosoftPowerPoint365/MicrosoftPowerpoint365.munki.recipe
+++ b/MicrosoftPowerPoint365/MicrosoftPowerpoint365.munki.recipe
@@ -14,6 +14,12 @@
         <string>apps/msoffice</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Microsoft AutoUpdate</string>
+                <string>Microsoft Error Reporting</string>
+                <string>Microsoft PowerPoint</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -24,14 +30,32 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftpowerpoint365</string>
+    <string>com.github.rtrouton.pkg.microsoftpowerpoint365</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftWord365/MicrosoftWord365.munki.recipe
+++ b/MicrosoftWord365/MicrosoftWord365.munki.recipe
@@ -14,6 +14,12 @@
         <string>apps/msoffice</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Microsoft AutoUpdate</string>
+                <string>Microsoft Error Reporting</string>
+                <string>Microsoft Word</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -24,14 +30,32 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftword365</string>
+    <string>com.github.rtrouton.pkg.microsoftword365</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/MicrosoftWord365/MicrosoftWord365.pkg.recipe
+++ b/MicrosoftWord365/MicrosoftWord365.pkg.recipe
@@ -66,6 +66,20 @@
             <string>Versioner</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>info_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Word.app/Contents/Info.plist</string>
+               <key>plist_keys</key>
+               <dict>
+                  <key>LSMinimumSystemVersion</key>
+                  <string>minimum_os_version</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
@@ -75,6 +89,46 @@
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%_%SOFTWARETITLE%_%version%.pkg</string>
             </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pkgroot</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>pkgdirs</key>
+               <dict>
+                  <key>Applications</key>
+                  <string>0775</string>
+               </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>source</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/Microsoft Word.app</string>
+               <key>target</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root/Applications/Microsoft Word.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>installs_item_paths</key>
+               <array>
+                  <string>/Applications/Microsoft Word.app</string>
+               </array>
+               <key>faux_root</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/payload/faux_root</string>
+               <key>version_comparison_key</key>
+               <string>%VERSIONTYPE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
          </dict>
          <dict>
             <key>Processor</key>


### PR DESCRIPTION
This pull request aims at the Munki recipes for the Microsoft Office 365 apps in the following regards:

- added a "blocking_applications" array for Word, Excel, PowerPoint, Outlook and OneNote
- added an "installs" array, containing the actual app bundle
- dynamically set the "minimum_os_version" key
- propose an "unattended_uninstall" in the default "pkginfo"
- some minor fixes:
  - Onedrive -> OneDrive
  - alphabetically ordering of plist keys

Since most of the changes requires an unpacking of the downloaded installer, I have added some necessary steps in the "pkg" recipes, since they are already unpacking those installers, and defined the pkg recipe as the parent recipe for the munki recipes. This leads to some output vars inside the pkg recipe which are only needed for the munki recipe.

Another option would be to move those steps to the munki recipes and copy over the unpackaging steps from the pkg recipe, which would lead to redundant code.

The installs array contains only the actual app bundle and not the AutoUpdate app or the licensing helper. This is intended. The AutoUpdater is not actually required to run the app, and the licensing helper should always be installed whenever the app gets installed initially. See Paul Bowden's post in [MacAdmins Slack](https://macadmins.slack.com/archives/C056155B4/p1537557087000100). Keeping these components out of the installs array enables a smoother Munki onboarding of clients which have previously installed the Office apps and used the AutoUpdater to install incremental updates. Since those incremental updates won't include the licensing helper, Munki may try to install an update even though it would not be necessary. This gets worse of the onboarded machine is on a beta channel: Munki would then try to install outdated office apps, only because the included licensing helper may be of a higher version.

