### PR TITLE
Update default VMware tools version series to 12

### DIFF
--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -5,14 +5,13 @@ from __future__ import absolute_import
 import re
 from xml.etree import ElementTree
 from xml.parsers.expat import ExpatError
-from distutils.version import LooseVersion
 
 try:
     from urlparse import urljoin
 except ImportError:
     from urllib.parse import urljoin
 
-from autopkglib import URLGetter, ProcessorError
+from autopkglib import APLooseVersion, ProcessorError, URLGetter
 
 __all__ = ["VMwareGuestToolsURLProvider"]
 
@@ -75,7 +74,7 @@ class VMwareGuestToolsURLProvider(URLGetter):
 
     def find_highest_version(self, versions_dict):
         """Find the URL of the highest version in the versions dictionary."""
-        return sorted(versions_dict.keys(), key=LooseVersion)[-1]
+        return sorted(versions_dict.keys(), key=APLooseVersion)[-1]
 
     def get_version_and_url(self, version_series):
         """Return the version and URL string for the Guest Tools."""

--- a/VMware-Tools/VMwareGuestToolsURLProvider.py
+++ b/VMware-Tools/VMwareGuestToolsURLProvider.py
@@ -18,7 +18,7 @@ __all__ = ["VMwareGuestToolsURLProvider"]
 
 FUSION_URL_BASE = "https://softwareupdate.vmware.com/cds/vmw-desktop/"
 DARWIN_TOOLS_URL_APPEND = "com.vmware.fusion.zip.tar"
-DEFAULT_VERSION_SERIES = "11.5.0"
+DEFAULT_VERSION_SERIES = "12.0.0"
 
 
 class VMwareGuestToolsURLProvider(URLGetter):


### PR DESCRIPTION
This will download the VMware tools version selected to match VMware Fusion major version 12 instead of 11.5.

Run output:

```
% autopkg run -vv VMware-Tools/VMwareTools.download.recipe
Processing VMware-Tools/VMwareTools.download.recipe...
WARNING: VMware-Tools/VMwareTools.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
VMwareGuestToolsURLProvider
{'Input': {}}
VMwareGuestToolsURLProvider: Base URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareGuestToolsURLProvider: Searching for version series 12.0.0
('12.1.0', '17195230')
('12.2.3', '19436697')
('12.1.1', '17801503')
('12.2.1', '18811640')
('12.2.0', '18760249')
('12.1.2', '17964953')
VMwareGuestToolsURLProvider: Latest version URL suffix: fusion/12.2.3/19436697/x86/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/12.2.3/19436697/x86/core/com.vmware.fusion.zip.tar
VMwareGuestToolsURLProvider: Version: 12.2.3
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/12.2.3/19436697/x86/core/com.vmware.fusion.zip.tar',
            'version': '12.2.3'}}
URLDownloader
{'Input': {'filename': 'VMwareTools.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/12.2.3/19436697/x86/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/downloads/VMwareTools.zip.tar
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/downloads/VMwareTools.zip.tar'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools-untar'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar' from filename VMwareTools.zip.tar
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/downloads/VMwareTools.zip.tar to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools-untar
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools'}}
Unarchiver: Guessed archive format 'zip' from filename com.vmware.fusion.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools-untar/com.vmware.fusion.zip to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools
{'Output': {}}
FileMover
{'Input': {'source': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools/payload/VMware '
                     'Fusion.app/Contents/Library/isoimages/darwin.iso',
           'target': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools.iso'}}
FileMover: File ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools/payload/VMware Fusion.app/Contents/Library/isoimages/darwin.iso moved to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools.iso
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/receipts/VMwareTools.download-receipt-20220413-083500.plist

Nothing downloaded, packaged or imported.
```