### PR TITLE
Fix NAME of two install recipes

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.install.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.install.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Firefox</string>
+        <string>Microsoft Teams</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>

--- a/MicrosoftYammer/MicrosoftYammer.install.recipe
+++ b/MicrosoftYammer/MicrosoftYammer.install.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Firefox</string>
+        <string>Microsoft Yammer</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>


### PR DESCRIPTION
These two NAMEs look leftover from initial recipe creation based on a Firefox template.