### PR TITLE
Update MicrosoftOffice365Suite.munki to use core processor

### DIFF
--- a/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
+++ b/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
@@ -73,7 +73,7 @@ appends the version to the end of the filename, and imports into Munki.
             <key>Arguments</key>
             <dict>
                 <key>predicate</key>
-                <string>munki_repo_changed != True</string>
+                <string>munki_repo_changed == False</string>
             </dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>

--- a/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
+++ b/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
@@ -54,7 +54,7 @@ appends the version to the end of the filename, and imports into Munki.
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.7</string>
     <key>Process</key>
     <array>
         <dict>
@@ -68,9 +68,19 @@ appends the version to the end of the filename, and imports into Munki.
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <!-- If nothing was imported then no need to run the Receipt Editor processor -->
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>munki_repo_changed != True</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>        
 		<dict>
 			<key>Processor</key>
-			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+			<string>MunkiOptionalReceiptEditor</string>
 		</dict>
     </array>
 </dict>

--- a/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
+++ b/MicrosoftOffice365Suite/MicrosoftOffice365Suite.munki.recipe
@@ -48,7 +48,7 @@ appends the version to the end of the filename, and imports into Munki.
             <key>category</key>
             <string>Productivity</string>
             <key>minimum_os_version</key>
-            <string>10.13.0</string>
+            <string>10.15.0</string>
             <key>name</key>
             <string>%NAME%</string>
         </dict>


### PR DESCRIPTION
Sam Keeley's MunkiPkginfoReceiptsEditor processor is not compatible with the version of Python shipping with AutoPkg 2.7.  There is a new core processor that can replace Sam's, so this pull request updates the MicrosoftOffice365Suite.munki  recipe to use the new processor.