### PR TITLE
Update Fiji.download.recipe

### DIFF
--- a/Fiji/Fiji.download.recipe
+++ b/Fiji/Fiji.download.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://imagej.nih.gov/ij/notes.html</string>
+                <string>https://wsr.imagej.net/notes.html</string>
                 <key>re_pattern</key>
                 <string>Version (&amp;gt;)?(?P&lt;version&gt;[0-9a-z\.]*)</string>
             </dict>


### PR DESCRIPTION
Notes URL for ImageJ has changed and the old URL is no longer accessible, requesting change to new URL.

Confirmed working in personal testing prior to lodging pull request.