### PR TITLE
Fix Microsoft Teams Munki Versioning and Receipts

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.munki.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.munki.recipe
@@ -53,6 +53,17 @@
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_ids_set_optional_true</key>
+                <array>
+                    <string>com.microsoft.MSTeamsAudioDevice</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiOptionalReceiptEditor</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/MicrosoftTeams/MicrosoftTeams.munki.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.munki.recipe
@@ -7,13 +7,19 @@
     <key>Identifier</key>
     <string>com.github.rtrouton.munki.microsoftteams</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.microsoftteams</string>
+    <string>com.github.rtrouton.pkg.microsoftteams</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>MicrosoftTeams</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Microsoft</string>
+        <key>VENDOR</key>
+         <string>Microsoft</string>
+         <key>SOFTWARETITLE</key>
+         <string>Teams</string>
+         <key>VERSIONTYPE</key>
+         <string>CFBundleShortVersionString</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -41,8 +47,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
This PR is to fix two separate but related issues with the munki recipe for Microsoft Teams.

I have changed the munki recipe to use the pkg recipe as a parent rather than the download one. This resolves an issue where Teams was being incorrectly imported to Munki with a version number based on the audio driver subpkg now present inside the Teams installer metapkg. The pkg recipe already accounted for this and contains PkgPayloadUnpacker and Versioner processors to determine the correct version number so I've just adopted that.

In addition to this it seems that the Teams Audio driver subpkg is not always installed in some situations. This results in an install loop where Teams would just continuously download and re-install with every Munki run. The issue is described in the [Munki Wiki](https://github.com/munki/munki/wiki/How-Munki-Decides-What-Needs-To-Be-Installed#receipts) in more detail and the proposed solution is to mark the pkg ids that are not always installed as "optional" in the pkginfo file receipts section. I have utilised the MunkiOptionalReceiptEditor processor to achieve this.

I've tested this recipe with my own workflow and am now able to have Teams install correctly without looping. The catch is that you do have to remove any pkginfo files from Munki where Teams has a higher version number based off the old recipe. For example, I had to remove Teams version listed as 2020.42.0 (multiple copies) and 2022.31.1 (multiple copies) so that the current version 1.00.528558 will install. It seems that this issue has only existed since about June and there haven't been too many versions released in that time.