### PR TITLE
universal build of citrix app

### DIFF
--- a/CitrixWorkspace/CitrixWorkspace.download.recipe
+++ b/CitrixWorkspace/CitrixWorkspace.download.recipe
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the latest Citrix Workspace disk image.</string>
-	<key>Identifier</key>
-	<string>com.github.rtrouton.download.citrixworkspace</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>CitrixWorkspace</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.0</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html</string>
-				<key>re_pattern</key>
-				<string>(?P&lt;DYNAMIC_URL&gt;//downloads.citrix.com/[\d]+/CitrixWorkspaceApp\.dmg\?__gda__\=exp\=(\w|\~|\=)+/(\w|\*|\~|\=)+)</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https:%DYNAMIC_URL%</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/Install Citrix Workspace.pkg</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-			</dict>
-		</dict>
-	</array>
-</dict>
+    <dict>
+        <key>Description</key>
+        <string>Downloads the latest Citrix Workspace disk image.</string>
+        <key>Identifier</key>
+        <string>com.github.rtrouton.download.citrixworkspace</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>CitrixWorkspace</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>1.0.0</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Processor</key>
+                <string>URLTextSearcher</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>url</key>
+                    <string>https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-native-support-for-silicon-mac.html</string>
+                    <key>re_pattern</key>
+                    <string>(?P&lt;DYNAMIC_URL&gt;//downloads.citrix.com/[\d]+/CitrixWorkspaceApp\.dmg\?__gda__\=exp\=(\w|\~|\=)+/(\w|\*|\~|\=)+)</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>URLDownloader</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>url</key>
+                    <string>https:%DYNAMIC_URL%</string>
+                    <key>filename</key>
+                    <string>%NAME%.dmg</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_path</key>
+                    <string>%pathname%/Install Citrix Workspace.pkg</string>
+                    <key>expected_authority_names</key>
+                    <array>
+                        <string>Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)</string>
+                        <string>Developer ID Certification Authority</string>
+                        <string>Apple Root CA</string>
+                    </array>
+                </dict>
+            </dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
There is now a separate link for the universal build of Citrix Workspace - https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-native-support-for-silicon-mac.html

I propose that the standard download recipe uses this new link.

Slight risk: as stated on the link above:

> Note: Citrix continues to support Intel-based Macs that use the Rosetta 2 dynamic binary translator. However, Citrix will soon deprecate the Citrix Workspace app for Mac that uses Rosetta emulation. Keep a look out for an announcement about the deprecation.

That probably means that this new link will be removed at some point in the future as the universal build becomes the standard. 

However, given the problems some of my customers are having with the Intel version with Rosetta, it would seem to be a good idea to switch to the Universal build now even if we potentially have to make another change down the line.