### PR TITLE
Update MicrosoftTeams.munki.recipe

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.munki.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.munki.recipe
@@ -47,6 +47,11 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>additional_makepkginfo_options</key>
+                <array>
+                    <string>--pkgvers</string>
+                    <string>%version%</string>
+                </array>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
Overrides the package version when calling the MunkiImporter processor. The makepkginfo code incorrectly grabs the version of the com.microsoft.MSTeamsAudioDevice component package instead of the version of the com.microsoft.teams component package when detecting the overall pkg version. Since we have the "correct" version available to use already, just tell makepkginfo to use it.