### PR TITLE
EndNote20 - support for `derive_minimum_os_version`

### DIFF
--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -11,7 +11,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 	<key>Input</key>
 	<dict>
 		<key>DERIVE_MIN_OS</key>
-        <string>YES</string>
+		<string>YES</string>
 		<key>DEFAULT_CATALOG</key>
 		<string>testing</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -89,7 +89,7 @@ done
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.rtrouton.pkg.EndNote20</string>
 	<key>Process</key>

--- a/EndNote/EndNote20.munki.recipe
+++ b/EndNote/EndNote20.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Endnote 20 installer and imports it into munki.</string>
+	<string>Downloads latest Endnote 20 installer and imports it into munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.rtrouton.munki.EndNote20</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+        <string>YES</string>
 		<key>DEFAULT_CATALOG</key>
 		<string>testing</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -28,8 +32,6 @@
 			<string>Thomson Reuters</string>
 			<key>display_name</key>
 			<string>EndNote 20</string>
-			<key>minimum_os_version</key>
-			<string>10.10.0</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -142,6 +144,8 @@ done
                 </array>
                 <key>version_comparison_key</key>
                 <string>CFBundleShortVersionString</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @rtrouton 

The Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, but 10.10.0 is hard coded in the recipe. 

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.14

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/rtrouton-recipes/EndNote/EndNote20.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/rtrouton-recipes/EndNote/EndNote20.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/rtrouton-recipes/EndNote/EndNote20.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 19 Jul 2022 15:00:55 GMT
URLDownloader: Storing new ETag header: "4d4d139758b6d3d2d67d0ac0f790a789-13"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
EndOfCheckPhase
Versioner
Versioner: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Versioner: Found version 20.4.0.18004 in file /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg/Install EndNote 20.app/Contents/Info.plist
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.K3GclC/Install EndNote 20.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.K3GclC/Install EndNote 20.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.K3GclC/Install EndNote 20.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Copier: Copied /private/tmp/dmg.fnUi7a/Install EndNote 20.app/Contents/Resources/EndNote.zip to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename EndNote.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive
Versioner
Versioner: Found version 20.4.0.18004 in file /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote/EndNote 20.app/Contents/Info.plist
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot/Applications
Copier
Copier: Copied /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive/EndNote to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot/Applications/EndNote 20
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/unarchive
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/pkgroot
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg
Copier: Copied /private/tmp/dmg.jptwfh/Install EndNote 20.app/Contents/Resources/EndNote.zip to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename EndNote.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications
FileMover
FileMover: File /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications/EndNote moved to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications/EndNote 20
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/EndNote 20/EndNote 20.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.14
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ThomsonResearchSoft.EndNote', 'CFBundleShortVersionString': '20.4.0.18004', 'CFBundleVersion': '2022.20.4.0.18004', 'minosversion': '10.14', 'path': '/Applications/EndNote 20/EndNote 20.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.14'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/EndNote 20/EndNote 20-20.4.0.18004.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/EndNote 20/EndNote-20.4.0.18004.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/Applications
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote.zip
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/receipts/EndNote20.munki-receipt-20230106-094123.plist

The following new items were downloaded:
    Download Path                                                                                   
    -------------                                                                                   
    /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/downloads/EndNote 20.dmg  

The following packages were built:
    Identifier                 Version       Pkg Path                                                                                        
    ----------                 -------       --------                                                                                        
    com.endnote.EndNote20.pkg  20.4.0.18004  /Users/paul/Library/AutoPkg/Cache/com.github.rtrouton.munki.EndNote20/EndNote-20.4.0.18004.pkg  

The following new items were imported into Munki:
    Name        Version       Catalogs  Pkginfo Path                                   Pkg Repo Path                             Icon Repo Path  
    ----        -------       --------  ------------                                   -------------                             --------------  
    EndNote 20  20.4.0.18004  testing   apps/EndNote 20/EndNote 20-20.4.0.18004.plist  apps/EndNote 20/EndNote-20.4.0.18004.pkg
```