### PR TITLE
Adjust minimum AutoPkg version for MunkiOptionalReceiptEditor

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.munki.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.munki.recipe
@@ -41,7 +41,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The MunkiOptionalReceiptEditor processor was included beginning in AutoPkg 2.7, so recipes that use this processor should have `MinimumVersion` set accordingly.