### PR TITLE
Update MicrosoftOneDrive.munki.recipe

### DIFF
--- a/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
+++ b/MicrosoftOneDrive/MicrosoftOneDrive.munki.recipe
@@ -41,6 +41,93 @@
         <dict>
             <key>Arguments</key>
             <dict>
+               <key>destination_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+               <key>flat_pkg_path</key>
+               <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pattern</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/unpack/*OneDrive*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>destination_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+               <key>pkg_payload_path</key>
+               <string>%found_filename%/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>input_plist_path</key>
+               <string>%RECIPE_CACHE_DIR%/downloads/Applications/OneDrive.app/Contents/Info.plist</string>
+               <key>plist_version_key</key>
+               <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/OneDrive.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
@@ -49,6 +136,18 @@
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+               <key>path_list</key>
+               <array>
+                  <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+                  <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+               </array>
+            </dict>
+         </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
add logic for installs array

the current recipe munki logic will actually DOWNGRADE OneDrive to a previous version if it is otherwise updated (OneDrive likes to auto-update itself). If this happens OneDrive is rendered corrupt and no longer works.

I have updated the munki recipe to allow for an installs array with the proper version string in it so this works as expected.

also bumped min macos version to 10.14 as that is required now.