### PR TITLE
Update Fiji.download.recipe

### DIFF
--- a/Fiji/Fiji.download.recipe
+++ b/Fiji/Fiji.download.recipe
@@ -22,11 +22,13 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://wsr.imagej.net/notes.html</string>
-                <key>re_pattern</key>
-                <string>Version (&amp;gt;)?(?P&lt;version&gt;[0-9a-z\.]*)</string>
-            </dict>
+				<key>url</key>
+				<string>https://maven.scijava.org/content/groups/public/sc/fiji/fiji/maven-metadata.xml</string>
+ 				<key>re_pattern</key>
+				<string>release&gt;(.*)&lt;\/release</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+           </dict>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
Current recipe is finding the latest ImageJ version but Fiji has a different versioning scheme (and often is a couple of ImageJ versions behind so even the version of ImageJ bundled is not what is being pulled).  This changes where Fiji version is sourced from to the Maven repository metadata.  It does change it significantly from the ImageJ version (being 1.54j or something) to the Fiji version (2.15.0 or something).