### PR TITLE
Update MicrosoftIntuneCompanyPortal.download.recipe

### DIFF
--- a/MicrosoftIntuneCompanyPortal/MicrosoftIntuneCompanyPortal.download.recipe
+++ b/MicrosoftIntuneCompanyPortal/MicrosoftIntuneCompanyPortal.download.recipe
@@ -21,7 +21,7 @@
          <key>SOFTWARETITLE3</key>
          <string>Portal</string>
          <key>PRODUCTID</key>
-         <string>869655</string>
+         <string>853070</string>
          <key>DOWNLOADURL</key>
          <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
       </dict>


### PR DESCRIPTION
Looks like the FWLink ID has changed.

https://go.microsoft.com/fwlink/?linkid=869655 no longer downloads the current release.

https://go.microsoft.com/fwlink/?linkid=853070 however does.

It was found here:
https://learn.microsoft.com/en-us/mem/intune/user-help/sign-in-to-the-company-portal#macos