### PR TITLE
update URL

### DIFF
--- a/ImageJ/ImageJ.download.recipe
+++ b/ImageJ/ImageJ.download.recipe
@@ -60,7 +60,7 @@
                 <key>result_output_var_name</key>
                 <string>match</string>
                 <key>url</key>
-                <string>https://imagej.nih.gov/ij/download.html</string>
+                <string>https://imagej.net/ij/download.html</string>
                 <key>re_pattern</key>
                 <string>https:\/\/wsr\.imagej\.net\/distros\/osx\/ij.*-osx-java8\.zip</string>
             </dict>


### PR DESCRIPTION
This updates the URL used to scrape the download link.  The URL https://imagej.nih.gov/ij/download.html no longer exists and is now https://imagej.net/ij/download.html