### PR TITLE
Fix SapMachine recipes and add ARCH input variable

### DIFF
--- a/SapMachine/SapMachine.download.recipe
+++ b/SapMachine/SapMachine.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
    <dict>
       <key>Description</key>
-      <string>Downloads the current release of SapMachine Java JDK from the SapMachine release page on Github: https://github.com/SAP/SapMachine/releases</string>
+      <string>Downloads the current release of SapMachine Java JDK from the SapMachine release page on Github: https://github.com/SAP/SapMachine/releases
+      
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "aarch64" (Apple Silicon)
+</string>
       <key>Identifier</key>
       <string>com.github.rtrouton.download.SapMachine</string>
       <key>Input</key>
@@ -14,6 +19,8 @@
          <string>SAP</string>
          <key>SOFTWARETITLE</key>
          <string>SapMachine</string>
+         <key>ARCH</key>
+         <string>x64</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -25,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                <key>asset_regex</key>
-               <string>sapmachine-jdk-[\S]+\_osx-x64_bin.dmg</string>
+               <string>.+_macos\-%ARCH%_bin\.dmg</string>
                <key>github_repo</key>
                <string>sap/sapmachine</string>
             </dict>


### PR DESCRIPTION
This PR adjusts the asset regex used to download SAPMachine releases from GitHub. It also adds an ARCH input variable that can be used to specify whether to download Intel or Apple Silicon versions.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'SapMachine/SapMachine.download.recipe'
Processing SapMachine/SapMachine.download.recipe...
WARNING: SapMachine/SapMachine.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.+_macos\\-x64_bin\\.dmg',
           'github_repo': 'sap/sapmachine'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.+_macos\-x64_bin\.dmg' among asset(s): sapmachine-jdk-23.0.1-1.x86_64.rpm, sapmachine-jdk-23.0.1-1.x86_64.rpm.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_aix-ppc64_bin.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin.tar.gz, sapmachine-jdk-23.0.1_linux-aarch64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-aarch64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-aarch64_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-aarch64_bin.tar.gz, sapmachine-jdk-23.0.1_linux-ppc64le_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-ppc64le_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-ppc64le_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-ppc64le_bin.tar.gz, sapmachine-jdk-23.0.1_linux-x64-musl_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-x64-musl_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-x64-musl_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-x64-musl_bin.tar.gz, sapmachine-jdk-23.0.1_linux-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-x64_bin.tar.gz, sapmachine-jdk-23.0.1_macos-aarch64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg, sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin.tar.gz, sapmachine-jdk-23.0.1_macos-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_macos-x64_bin.dmg, sapmachine-jdk-23.0.1_macos-x64_bin.dmg.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin.tar.gz, sapmachine-jdk-23.0.1_windows-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_windows-x64_bin.msi, sapmachine-jdk-23.0.1_windows-x64_bin.msi.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin.zip, sapmachine-jre-23.0.1_aix-ppc64_bin.sha256.txt, sapmachine-jre-23.0.1_aix-ppc64_bin.tar.gz, sapmachine-jre-23.0.1_linux-aarch64_bin.sha256.txt, sapmachine-jre-23.0.1_linux-aarch64_bin.tar.gz, sapmachine-jre-23.0.1_linux-ppc64le_bin.sha256.txt, sapmachine-jre-23.0.1_linux-ppc64le_bin.tar.gz, sapmachine-jre-23.0.1_linux-x64-musl_bin.sha256.txt, sapmachine-jre-23.0.1_linux-x64-musl_bin.tar.gz, sapmachine-jre-23.0.1_linux-x64_bin.sha256.txt, sapmachine-jre-23.0.1_linux-x64_bin.tar.gz, sapmachine-jre-23.0.1_macos-aarch64_bin.dmg, sapmachine-jre-23.0.1_macos-aarch64_bin.dmg.sha256.txt, sapmachine-jre-23.0.1_macos-aarch64_bin.sha256.txt, sapmachine-jre-23.0.1_macos-aarch64_bin.tar.gz, sapmachine-jre-23.0.1_macos-x64_bin.dmg, sapmachine-jre-23.0.1_macos-x64_bin.dmg.sha256.txt, sapmachine-jre-23.0.1_macos-x64_bin.sha256.txt, sapmachine-jre-23.0.1_macos-x64_bin.tar.gz, sapmachine-jre-23.0.1_windows-x64_bin.msi, sapmachine-jre-23.0.1_windows-x64_bin.msi.sha256.txt, sapmachine-jre-23.0.1_windows-x64_bin.sha256.txt, sapmachine-jre-23.0.1_windows-x64_bin.zip
GitHubReleasesInfoProvider: Selected asset 'sapmachine-jdk-23.0.1_macos-x64_bin.dmg' from release 'sapmachine-23.0.1'
{'Output': {'asset_created_at': '2024-10-15T17:35:51Z',
            'asset_url': 'https://api.github.com/repos/SAP/SapMachine/releases/assets/199308137',
            'url': 'https://github.com/SAP/SapMachine/releases/download/sapmachine-23.0.1/sapmachine-jdk-23.0.1_macos-x64_bin.dmg',
            'version': 'sapmachine-23.0.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/SAP/SapMachine/releases/download/sapmachine-23.0.1/sapmachine-jdk-23.0.1_macos-x64_bin.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Oct 2024 17:35:59 GMT
URLDownloader: Storing new ETag header: "0x8DCED3FD53CA9BC"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-x64_bin.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DCED3FD53CA9BC"',
            'last_modified': 'Tue, 15 Oct 2024 17:35:59 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-x64_bin.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-x64_bin.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/receipts/SapMachine.download-receipt-20241227-212105.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-x64_bin.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'SapMachine/SapMachine.download.recipe' -k ARCH=aarch64
Processing SapMachine/SapMachine.download.recipe...
WARNING: SapMachine/SapMachine.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.+_macos\\-aarch64_bin\\.dmg',
           'github_repo': 'sap/sapmachine'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.+_macos\-aarch64_bin\.dmg' among asset(s): sapmachine-jdk-23.0.1-1.x86_64.rpm, sapmachine-jdk-23.0.1-1.x86_64.rpm.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_aix-ppc64_bin.sha256.txt, sapmachine-jdk-23.0.1_aix-ppc64_bin.tar.gz, sapmachine-jdk-23.0.1_linux-aarch64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-aarch64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-aarch64_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-aarch64_bin.tar.gz, sapmachine-jdk-23.0.1_linux-ppc64le_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-ppc64le_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-ppc64le_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-ppc64le_bin.tar.gz, sapmachine-jdk-23.0.1_linux-x64-musl_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-x64-musl_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-x64-musl_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-x64-musl_bin.tar.gz, sapmachine-jdk-23.0.1_linux-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_linux-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_linux-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_linux-x64_bin.tar.gz, sapmachine-jdk-23.0.1_macos-aarch64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg, sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin.sha256.txt, sapmachine-jdk-23.0.1_macos-aarch64_bin.tar.gz, sapmachine-jdk-23.0.1_macos-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_macos-x64_bin.dmg, sapmachine-jdk-23.0.1_macos-x64_bin.dmg.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_macos-x64_bin.tar.gz, sapmachine-jdk-23.0.1_windows-x64_bin-symbols.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin-symbols.tar.gz, sapmachine-jdk-23.0.1_windows-x64_bin.msi, sapmachine-jdk-23.0.1_windows-x64_bin.msi.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin.sha256.txt, sapmachine-jdk-23.0.1_windows-x64_bin.zip, sapmachine-jre-23.0.1_aix-ppc64_bin.sha256.txt, sapmachine-jre-23.0.1_aix-ppc64_bin.tar.gz, sapmachine-jre-23.0.1_linux-aarch64_bin.sha256.txt, sapmachine-jre-23.0.1_linux-aarch64_bin.tar.gz, sapmachine-jre-23.0.1_linux-ppc64le_bin.sha256.txt, sapmachine-jre-23.0.1_linux-ppc64le_bin.tar.gz, sapmachine-jre-23.0.1_linux-x64-musl_bin.sha256.txt, sapmachine-jre-23.0.1_linux-x64-musl_bin.tar.gz, sapmachine-jre-23.0.1_linux-x64_bin.sha256.txt, sapmachine-jre-23.0.1_linux-x64_bin.tar.gz, sapmachine-jre-23.0.1_macos-aarch64_bin.dmg, sapmachine-jre-23.0.1_macos-aarch64_bin.dmg.sha256.txt, sapmachine-jre-23.0.1_macos-aarch64_bin.sha256.txt, sapmachine-jre-23.0.1_macos-aarch64_bin.tar.gz, sapmachine-jre-23.0.1_macos-x64_bin.dmg, sapmachine-jre-23.0.1_macos-x64_bin.dmg.sha256.txt, sapmachine-jre-23.0.1_macos-x64_bin.sha256.txt, sapmachine-jre-23.0.1_macos-x64_bin.tar.gz, sapmachine-jre-23.0.1_windows-x64_bin.msi, sapmachine-jre-23.0.1_windows-x64_bin.msi.sha256.txt, sapmachine-jre-23.0.1_windows-x64_bin.sha256.txt, sapmachine-jre-23.0.1_windows-x64_bin.zip
GitHubReleasesInfoProvider: Selected asset 'sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg' from release 'sapmachine-23.0.1'
{'Output': {'asset_created_at': '2024-10-15T17:35:21Z',
            'asset_url': 'https://api.github.com/repos/SAP/SapMachine/releases/assets/199307991',
            'url': 'https://github.com/SAP/SapMachine/releases/download/sapmachine-23.0.1/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg',
            'version': 'sapmachine-23.0.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/SAP/SapMachine/releases/download/sapmachine-23.0.1/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Oct 2024 17:35:29 GMT
URLDownloader: Storing new ETag header: "0x8DCED3FC37B5D38"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DCED3FC37B5D38"',
            'last_modified': 'Tue, 15 Oct 2024 17:35:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/receipts/SapMachine.download-receipt-20241227-212125.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-23.0.1_macos-aarch64_bin.dmg
```
