### PR TITLE
Deprecate AdwareMedic recipes

### DIFF
--- a/AdwareMedic/AdwareMedic.download.recipe
+++ b/AdwareMedic/AdwareMedic.download.recipe
@@ -14,9 +14,18 @@
         <string>https://www.adwaremedic.com/versions/updates.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the MalwarebytesAntiMalware recipes elsewhere in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
This PR deprecates the Adware Medic recipes, as that software is now Malwarebytes AntiMalware.
