### PR TITLE
Deprecate Mural recipes

### DIFF
--- a/MURAL/MURAL.download.recipe
+++ b/MURAL/MURAL.download.recipe
@@ -18,9 +18,18 @@
         <string>https://download.mural.co/mac-app/MURAL-[\S]+\.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Mural recipes in the paul-cossey-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional Mural recipes in this repo, and points users towards working equivalents in the paul-cossey-recipes repo.
