### PR TITLE
Change parent recipe of RStudio.pkg

### DIFF
--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -12,10 +12,19 @@
         <string>RStudio</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
-       <dict>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the RStudio recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>

--- a/RStudio/RStudio.pkg.recipe
+++ b/RStudio/RStudio.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest RStudio disk image and builds a package. The installer package includes a preinstall script that will check for an existing RStudio.app in /Applications and remove it if found.</string>
+    <string>Downloads the latest RStudio disk image and builds a package.</string>
     <key>Identifier</key>
     <string>com.github.rtrouton.pkg.RStudio</string>
     <key>Input</key>
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.download.RStudio</string>
+    <string>com.github.hansen-m.download.RStudio</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This PR switches the parent recipe of RStudio.pkg to the hansen-m download recipe, and deprecates the download recipe in this repo.

Verboose recipe run output:

```
% autopkg run -vvq RStudio.pkg.recipe
Processing RStudio.pkg.recipe...
WARNING: RStudio.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<dmg>RStudio-(?P<version>([0-9.]+){1,3}?.*).dmg)',
           'url': 'https://posit.co/download/rstudio-desktop/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (dmg): RStudio-2024.12.0-467.dmg
URLTextSearcher: Found matching text (version): 2024.12.0-467
URLTextSearcher: Found matching text (match): RStudio-2024.12.0-467.dmg
{'Output': {'dmg': 'RStudio-2024.12.0-467.dmg',
            'match': 'RStudio-2024.12.0-467.dmg',
            'version': '2024.12.0-467'}}
URLDownloader
{'Input': {'filename': 'RStudio.dmg',
           'url': 'https://download1.rstudio.org/electron/macos/RStudio-2024.12.0-467.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 16 Dec 2024 19:48:31 GMT
URLDownloader: Storing new ETag header: "1e8958921cf4d564a78efb09cd4307b1-74"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg
{'Output': {'download_changed': True,
            'etag': '"1e8958921cf4d564a78efb09cd4307b1-74"',
            'last_modified': 'Mon, 16 Dec 2024 19:48:31 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg/RStudio.app',
           'requirement': 'identifier "org.rstudio.RStudio" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FYF2F5GFX4'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.w0x5AC/RStudio.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.w0x5AC/RStudio.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.w0x5AC/RStudio.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg
AppDmgVersioner: BundleID: com.rstudio.desktop
AppDmgVersioner: Version: 2024.12.0+467
{'Output': {'app_name': 'RStudio.app',
            'bundleid': 'com.rstudio.desktop',
            'version': '2024.12.0+467'}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'split_on': '+', 'version': '2024.12.0+467'}}
VersionSplitter: Split version: 2024.12.0
{'Output': {'version': '2024.12.0'}}
AppPkgCreator
{'Input': {'bundleid': 'com.rstudio.desktop', 'version': '2024.12.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ULiacB/RStudio.app' matched from globbed '/private/tmp/dmg.ULiacB/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.ULiacB/RStudio.app to ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/payload/Applications/RStudio.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.rstudio.desktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/RStudio-2024.12.0.pkg',
                                                        'version': '2024.12.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2024.12.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/receipts/RStudio.pkg-receipt-20241230-200447.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/downloads/RStudio.dmg

The following packages were built:
    Identifier           Version    Pkg Path
    ----------           -------    --------
    com.rstudio.desktop  2024.12.0  ~/Library/AutoPkg/Cache/com.github.rtrouton.pkg.RStudio/RStudio-2024.12.0.pkg
```

