### PR TITLE
Deprecate AutoPkgr recipes

### DIFF
--- a/AutoPkgr/AutoPkgr.download.recipe
+++ b/AutoPkgr/AutoPkgr.download.recipe
@@ -12,9 +12,18 @@
 		<string>AutoPkgr</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the AutoPkgr recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The AutoPkgr recipes in this repo don't seem to be meaningfully different than the existing ones in my homebysix-recipes repo. The only difference I can see is a preinstall script for the pkg that removes AutoPkgr before installing it, which shouldn't be necessary.

This PR deprecates the AutoPkgr recipes in this repo and points users to the ones in homebysix-recipes.
