### PR TITLE
Add code signature verification for VMWare Tools (via Fusion app)

### DIFF
--- a/VMware-Tools/VMwareTools.download.recipe
+++ b/VMware-Tools/VMwareTools.download.recipe
@@ -54,6 +54,17 @@
 			</dict>
 			<dict>
 				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/payload/VMware Fusion.app</string>
+					<key>requirement</key>
+					<string>identifier "com.vmware.fusion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EG7KH642X6</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
 				<string>FileMover</string>
 				<key>Arguments</key>
 				<dict>


### PR DESCRIPTION
This PR adds code signature verification to the VMwareTools recipe (via the VMware Fusion app as a proxy).

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools/payload/VMware Fusion.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools/payload/VMware Fusion.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.rtrouton.download.VMwareTools/VMwareTools/payload/VMware Fusion.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```
