### PR TITLE
Update VMwareHorizonClient.pkg.recipe (App Renamed to Omnissa Horizon…

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.pkg.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.pkg.recipe
@@ -3,15 +3,15 @@
 <plist version="1.0">
    <dict>
       <key>Description</key>
-      <string>Downloads the latest VMware Horizon Client disk image, extracts the installer package and prepares it for deployment.</string>
+      <string>Downloads the latest Omnissa Horizon Client disk image, extracts the installer package and prepares it for deployment.</string>
       <key>Identifier</key>
       <string>com.github.rtrouton.pkg.VMwareHorizonClient</string>
       <key>Input</key>
       <dict>
          <key>NAME</key>
-         <string>VMwareHorizonClient</string>
+         <string>OmnissaHorizonClient</string>
          <key>VENDOR</key>
-         <string>VMware</string>
+         <string>Omnissa</string>
          <key>SOFTWARETITLE1</key>
          <string>Horizon</string>
          <key>SOFTWARETITLE2</key>
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                <key>flat_pkg_path</key>
-               <string>%pathname%/VMware Horizon Client.pkg</string>
+               <string>%pathname%/Omnissa Horizon Client.pkg</string>
                <key>destination_path</key>
                <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                <key>pkg_payload_path</key>
-               <string>%RECIPE_CACHE_DIR%/unpack/VMware.Horizon.Client.pkg/Payload</string>
+               <string>%RECIPE_CACHE_DIR%/unpack/Omnissa.Horizon.Client.pkg/Payload</string>
                <key>destination_path</key>
                <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>
@@ -53,7 +53,7 @@
             <key>Arguments</key>
             <dict>
                <key>input_plist_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload/VMware Horizon Client.app/Contents/Info.plist</string>
+               <string>%RECIPE_CACHE_DIR%/payload/Omnissa Horizon Client.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
                <string>CFBundleShortVersionString</string>
             </dict>
@@ -64,7 +64,7 @@
             <key>Arguments</key>
             <dict>
                <key>source_pkg</key>
-               <string>%pathname%/VMware Horizon Client.pkg</string>
+               <string>%pathname%/Omnissa Horizon Client.pkg</string>
                <key>pkg_path</key>
                <string>%RECIPE_CACHE_DIR%/%VENDOR%%SOFTWARETITLE1%%SOFTWARETITLE2%-%version%.pkg</string>
             </dict>


### PR DESCRIPTION
… Client)

App and Package are renamed by Vendor
Needs additional changes in Overrides and other Recipes


depends on: https://github.com/autopkg/scriptingosx-recipes/pull/104
