### PR TITLE
Update pkg signature expected authority name after recently change by Slack

### DIFF
--- a/Slack/SlackUniversal.download.recipe
+++ b/Slack/SlackUniversal.download.recipe
@@ -45,7 +45,7 @@
                <string>%pathname%</string>
                <key>expected_authority_names</key>
                <array>
-                  <string>Developer ID Installer: Slack Technologies, Inc. (BQR82RBBHL)</string>
+                  <string>Developer ID Installer: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)</string>
                   <string>Developer ID Certification Authority</string>
                   <string>Apple Root CA</string>
                </array>


### PR DESCRIPTION
Looks like Slack updated a cert and the name changed slightly at version 4.42.120 on 2/17/25.

`Developer ID Installer: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)` is the new 1st authority string on the universal pkg. 

Old vs new:
```
CodeSignatureVerifier: Expected: Developer ID Installer: Slack Technologies, Inc. (BQR82RBBHL) -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL) -> Developer ID Certification Authority -> Apple Root CA
```

They noted the change on their releases page:
https://slack.com/release-notes/mac

_"Starting with this version, Slack has changed our company registration in the MacOS desktop signing certificate from SLACK TECHNOLOGIES INC to SLACK TECHNOLOGIES, LLC following a similar change to our Windows desktop signing certificate in 2023. This change has been updated with our certificate registrar, and SLACK TECHNOLOGIES, LLC is the valid and correct publisher for new versions of Slack. If you’re suddenly seeing Slack being flagged by anti-virus software, the new binary and publisher name may need to be allowlisted by your company’s security policies. Many thanks for your understanding!"_