### PR TITLE
fix: Update signatures in Apple Silicon / Intel packages too (see #208)

### DIFF
--- a/Slack/SlackAppleSilicon.download.recipe
+++ b/Slack/SlackAppleSilicon.download.recipe
@@ -45,7 +45,7 @@
                <string>%pathname%</string>
                <key>expected_authority_names</key>
                <array>
-                  <string>Developer ID Installer: Slack Technologies, Inc. (BQR82RBBHL)</string>
+                  <string>Developer ID Installer: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)</string>
                   <string>Developer ID Certification Authority</string>
                   <string>Apple Root CA</string>
                </array>

--- a/Slack/SlackIntel.download.recipe
+++ b/Slack/SlackIntel.download.recipe
@@ -45,7 +45,7 @@
                <string>%pathname%</string>
                <key>expected_authority_names</key>
                <array>
-                  <string>Developer ID Installer: Slack Technologies, Inc. (BQR82RBBHL)</string>
+                  <string>Developer ID Installer: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)</string>
                   <string>Developer ID Certification Authority</string>
                   <string>Apple Root CA</string>
                </array>


### PR DESCRIPTION
The signatures for the Universal package were updated with #208 but the individual Apple Silicon and Intel installers seem to be needing the same fix.