### PR TITLE
Update PolyLens.download.recipe

### DIFF
--- a/PolyLens/PolyLens.download.recipe
+++ b/PolyLens/PolyLens.download.recipe
@@ -19,7 +19,7 @@
          <key>DATA_BINARY_CONTENT</key>
          <string>{"query":"\n          query {\n            availableProductSoftwareByPid(pid:\"lens-desktop-mac\") {\n              name\n              version\n              publishDate\n              productBuild {\n                archiveUrl\n              }\n            }\n        }"}</string>
          <key>SEARCH_PATTERN</key>
-         <string>https://swupdate\.lens\.poly\.com/lens-desktop-mac/.*?/.*?/PolyLens-.*?.dmg</string>
+         <string>https://swupdate\.lens\.poly\.com/lens-desktop-mac/.*?/.*?/LensDesktop-.*?.dmg</string>
       </dict>
       <key>MinimumVersion</key>
       <string>1.0.0</string>
@@ -57,6 +57,21 @@
             <key>Processor</key>
             <string>URLDownloader</string>
          </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/LensDesktop-*.pkg</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Polycom (WJCM3F7AQ4)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
       </array>
    </dict>
 </plist>


### PR DESCRIPTION
Hi, @rtrouton 

PolyLens download recipe  is failing with the current SEARCH_PATTERN due to change in the file name. 

This PR 
- Updates the SEARCH_PATTERN
-  Adds CodeSignatureVerifier

Looks like there is a rebrand happening https://info.lens.poly.com/blog/2025/03/20/ldt-2-0-mac not sure if you'd rather a new recipe to reflect or happy with just updating this. (FWIW I'm writing a new Munki recipe with this as the parent) 

Output from a -v run 
```
autopkg run -v PolyLens.download.recipe 
**load_recipe time: 0.0005018750089220703
Processing PolyLens.download.recipe...
WARNING: PolyLens.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://swupdate.lens.poly.com/lens-desktop-mac/2.0.0.632/2.0.0.632/LensDesktop-2.0.0.632.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 19 Mar 2025 19:57:31 GMT
URLDownloader: Storing new ETag header: "0x8DD6720490E6EC3"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.rtrouton.download.polylens/downloads/LensDesktop-2.0.0.632.dmg
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.rtrouton.download.polylens/downloads/LensDesktop-2.0.0.632.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.FTwMqc/LensDesktop-2.0.0.632.pkg' matched from globbed '/private/tmp/dmg.FTwMqc/LensDesktop-*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "LensDesktop-2.0.0.632.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-03-13 04:43:15 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Polycom (WJCM3F7AQ4)
CodeSignatureVerifier:        Expires: 2030-01-28 17:31:40 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            FB 95 D8 EA 65 AE 42 ED FB 2B F8 BC 88 54 CD 6E AB A8 4B CA DB 17 
CodeSignatureVerifier:            4C D3 A8 B7 0A 10 D8 65 4C 1B
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.rtrouton.download.polylens/receipts/PolyLens.download-receipt-20250327-213048.plist

The following new items were downloaded:
    Download Path                                                                                                       
    -------------                                                                                                       
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.rtrouton.download.polylens/downloads/LensDesktop-2.0.0.632.dmg
```