### PR TITLE
Fix for Citrix Workspace pkg recipe

### DIFF
--- a/CitrixWorkspace/CitrixWorkspace.pkg.recipe
+++ b/CitrixWorkspace/CitrixWorkspace.pkg.recipe
@@ -44,28 +44,6 @@
             <string>PkgPayloadUnpacker</string>
          </dict>
          <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>flat_pkg_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/CitrixPackage/com.citrix.apps.cwa.pkg</string>
-               <key>destination_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload2</string>
-            </dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>pkg_payload_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload2/com.citrix.ICAClientcwa.pkg/Payload</string>
-               <key>destination_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload3</string>
-            </dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-         </dict>
-         <dict>
             <key>Comment</key>
             <string>Get version from the pkg</string>
             <key>Processor</key>
@@ -73,7 +51,7 @@
             <key>Arguments</key>
             <dict>
                <key>input_plist_path</key>
-               <string>%RECIPE_CACHE_DIR%/payload3/Applications/Citrix Workspace.app/Contents/Info.plist</string>
+               <string>%RECIPE_CACHE_DIR%/payload/Applications/Citrix Workspace.app/Contents/Info.plist</string>
                <key>plist_version_key</key>
                <string>CFBundleShortVersionString</string>
             </dict>
@@ -187,8 +165,6 @@ exit $ERROR</string>
                <key>path_list</key>
                <array>
                   <string>%RECIPE_CACHE_DIR%/payload</string>
-                  <string>%RECIPE_CACHE_DIR%/payload2</string>
-                  <string>%RECIPE_CACHE_DIR%/payload3</string>
                   <string>%RECIPE_CACHE_DIR%/unpack</string>
                   <string>%RECIPE_CACHE_DIR%/Scripts</string>
                </array>


### PR DESCRIPTION
Citrix made a change to the structure of the pkgs inside pkgs inside pkgs inside pkgs so that we only need to look 2 levels deep for the app bundle instead of 4.

This only traverses the 2 levels needed and adjusts the path for versioner to find the app bundle. Also removes the deletion of folders that aren't there anymore.

Fix for #214 