### PR TITLE
Update AdobeCreativeCloudInstaller.download.recipe

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -18,7 +18,7 @@
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
 		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
+		<string>https://helpx.adobe.com/download-install/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>


### PR DESCRIPTION
Update Creative Cloud download recipe search url to updated download site with links:

https://helpx.adobe.com/download-install/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html