### PR TITLE
Update download URLs for Adobe Creative Cloud Installer Packages

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
@@ -19,7 +19,7 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
 		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>
 		<string>macarm64</string>
 	</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -20,9 +20,9 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
 		<key>INTEL_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>APPLE_SILICON_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>INTEL_ARCHITECTURE</key>
 		<string>osx10</string>
 		<key>APPLE_SILICON_ARCHITECTURE</key>


### PR DESCRIPTION
The download URL on the page changed:

Example:

Old: `https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.6.0/macarm64/ACCCx6_6_0_611.dmg`

New: `https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.6.0/611/macarm64/ACCCx6_6_0_611.dmg`

There is an additional part before the architecture now. I have added the path with a second regex.