### PR TITLE
New search page url for Adobe CCDA

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -18,7 +18,7 @@
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
 		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
+		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
@@ -17,7 +17,7 @@
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
 		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
+		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -18,7 +18,7 @@
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
 		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
+		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>INTEL_SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>APPLE_SILICON_SEARCH_PATTERN</key>


### PR DESCRIPTION
Today I noticed the Adobe CCDA recipe failing. While [it's been janky of late](https://github.com/autopkg/rtrouton-recipes/issues/217), it would occasionally still work when the old search page URL served something it could parse. I was working around that issue with a [tweaked `URLTestSeacher` processor](https://github.com/autopkg/rtrouton-recipes/issues/217#issuecomment-2891264076) and it was working well...until today. 

Today that old URL just flat doesn't serve anything useful. Whilst poking around [the old page](https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-from-web.html) to see what changed, I noticed in the sidebar "[Download Creative Cloud desktop app using direct links](https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html)"...that sounds like what we want anyway. It has links for the AppleSi and Intel apps.

As far as I can tell...seems to be finding what it was on the old URL, no changes to the regex needed, just the the `SEARCH_URL` switched. 

Bonus nachos....the weirdness that the old URL had seems to be gone....in testing so far the content of that URL doesn't change from check to check randomly like it has been.