### PR TITLE
Outlook updates

### DIFF
--- a/MicrosoftOutlook365/MicrosoftOutlook365.download.recipe
+++ b/MicrosoftOutlook365/MicrosoftOutlook365.download.recipe
@@ -7,7 +7,7 @@
       <key>Identifier</key>
       <string>com.github.rtrouton.download.microsoftoutlook365</string>
       <key>MinimumVersion</key>
-      <string>1.0.0</string>
+      <string>1.4</string>
       <key>Input</key>
       <dict>
          <key>NAME</key>

--- a/MicrosoftOutlook365/MicrosoftOutlook365.download.recipe
+++ b/MicrosoftOutlook365/MicrosoftOutlook365.download.recipe
@@ -16,20 +16,29 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Outlook</string>
-         <key>PRODUCTID</key>
-         <string>525137</string>
-         <key>DOWNLOADURL</key>
-         <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
       </dict>
       <key>Process</key>
       <array>
+         <dict>
+            <key>Processor</key>
+            <string>CURLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+               <key>url</key>
+               <string>https://learn.microsoft.com/en-us/officeupdates/update-history-office-for-mac</string>
+               <key>re_pattern</key>
+               <string>(https?://officecdn\.microsoft\.com/pr/[^/]+/MacAutoupdate/Microsoft_Outlook_[0-9.]+_Updater\.pkg)</string>
+               <key>result_output_var_name</key>
+               <string>url</string>
+            </dict>
+         </dict>
          <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                <key>url</key>
-               <string>%DOWNLOADURL%</string>
+               <string>%url%</string>
                <key>filename</key>
                <string>%VENDOR%_%SOFTWARETITLE%.pkg</string>
             </dict>


### PR DESCRIPTION
Microsoft publishes patch updates (Update packages) to all office apps on a weekly basis. The recipes in this repo (using the fwlinks) are working for Word, Excel, OneNote, PowerPoint and Teams. The fwlink for Outlook points at the suite version (Install package) that is only released every four weeks.

Please see the [documentation](https://learn.microsoft.com/en-us/officeupdates/update-history-office-for-mac) from Microsoft regarding the release dates. All downloads using the MicrosoftOutlook365.download.recipe this year only downloaded the suite version. The downloads were triggered at least twice per day.

Please see the output of `autopkg run -vvq MicrosoftOutlook365.download.recipe` without the patch (please note the `last_modified` date):
```
Processing MicrosoftOutlook365.download.recipe...
WARNING: MicrosoftOutlook365.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Microsoft_Outlook.pkg',
           'url': 'https://go.microsoft.com/fwlink/?linkid=525137'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 16 Sep 2025 15:57:30 GMT
URLDownloader: Storing new ETag header: "0xC152E40C66E66FFF4A4E77B9105689AF3B0BCABD6D8BC6A568EB5FBA98BF8DF7"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg
{'Output': {'download_changed': True,
            'etag': '"0xC152E40C66E66FFF4A4E77B9105689AF3B0BCABD6D8BC6A568EB5FBA98BF8DF7"',
            'last_modified': 'Tue, 16 Sep 2025 15:57:30 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Microsoft '
                                        'Corporation (UBF8T346G9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Microsoft_Outlook.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-09-13 22:00:38 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            64 5D 86 D2 DF 76 9E D7 04 CF B1 FA 1B 38 7F 78 69 DC 87 12 AB 4E 
CodeSignatureVerifier:            0F BC EB BC 29 64 D3 E9 A9 48
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/receipts/MicrosoftOutlook365.download-receipt-20250924-112635.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg
```
compared to the version using this patch:
```
Processing MicrosoftOutlook365.download.recipe...
WARNING: MicrosoftOutlook365.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CURLTextSearcher
{'Input': {'re_pattern': '(https?://officecdn\\.microsoft\\.com/pr/[^/]+/MacAutoupdate/Microsoft_Outlook_[0-9.]+_Updater\\.pkg)',
           'result_output_var_name': 'url',
           'url': 'https://learn.microsoft.com/en-us/officeupdates/update-history-office-for-mac'}}
URLTextSearcher: Found matching text (url): https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.101.25092124_Updater.pkg
{'Output': {'url': 'https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.101.25092124_Updater.pkg'}}
URLDownloader
{'Input': {'filename': 'Microsoft_Outlook.pkg',
           'url': 'https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.101.25092124_Updater.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 23 Sep 2025 16:52:42 GMT
URLDownloader: Storing new ETag header: "0x7ABB9E11AA11AE6C345E1671B1C3CF3DC9457415046703A42CBDF44942C7464D"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg
{'Output': {'download_changed': True,
            'etag': '"0x7ABB9E11AA11AE6C345E1671B1C3CF3DC9457415046703A42CBDF44942C7464D"',
            'last_modified': 'Tue, 23 Sep 2025 16:52:42 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Microsoft '
                                        'Corporation (UBF8T346G9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Microsoft_Outlook.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-09-22 05:28:13 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            64 5D 86 D2 DF 76 9E D7 04 CF B1 FA 1B 38 7F 78 69 DC 87 12 AB 4E 
CodeSignatureVerifier:            0F BC EB BC 29 64 D3 E9 A9 48
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/receipts/MicrosoftOutlook365.download-receipt-20250924-120705.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftoutlook365/downloads/Microsoft_Outlook.pkg
```
It is probably easier to see the difference when running the .pkg recipe outputting the version string.

We can also offer this download recipe in [our](https://github.com/autopkg/wycomco-recipes/) repo if you prefer to stick with the `fwlink` url.

**Update:** After switching to `2228621` as %PRODUCTID% in the override recipe, the current version was downloaded using the unchanged parent recipe from the master branch. Even after removing the key in the override recipe, the current version was downloaded. More investigation needed.