### PR TITLE
Update CCDA CDN domain

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -20,7 +20,7 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>
 		<string>osx10</string>
 	</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
@@ -19,7 +19,7 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>
 		<string>macarm64</string>
 	</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -20,9 +20,9 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>INTEL_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>APPLE_SILICON_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>INTEL_ARCHITECTURE</key>
 		<string>osx10</string>
 		<key>APPLE_SILICON_ARCHITECTURE</key>


### PR DESCRIPTION
They seem to have decided they didn't like the 's' in the domain anymore...

<img width="1672" height="972" alt="CleanShot 2025-10-01 at 08 26 23" src="https://github.com/user-attachments/assets/28ccde06-f96a-4147-9b22-d2ecd102d313" />
