### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.pkg.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.pkg.recipe
@@ -360,8 +360,6 @@ exit 0</string>
                   <string>com.adobe.AdobeCreativeCloudInstallerUniversal</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/AdwareMedic/AdwareMedic.pkg.recipe
+++ b/AdwareMedic/AdwareMedic.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.thesafemac.adwaremedic</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/AutoPkgr/AutoPkgr.pkg.recipe
+++ b/AutoPkgr/AutoPkgr.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.lindegroup.AutoPkgr</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/Barebones/BBEdit.pkg.recipe
+++ b/Barebones/BBEdit.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.barebones.bbedit.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>BBEdit_Scripts</string>
                     <key>chown</key>

--- a/Brisk/Brisk.pkg.recipe
+++ b/Brisk/Brisk.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.brisk.brisk</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/CarouselCloudScreenSaver/CarouselCloudScreenSaver.pkg.recipe
+++ b/CarouselCloudScreenSaver/CarouselCloudScreenSaver.pkg.recipe
@@ -117,8 +117,6 @@ exit $ERROR</string>
                   <string>%version%</string>
                   <key>id</key>
                   <string>com.trms.Carousel-Cloud-Screensaver</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>scripts</key>
                   <string>Scripts</string>
                   <key>chown</key>

--- a/Cyberduck/Cyberduck.pkg.recipe
+++ b/Cyberduck/Cyberduck.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>ch.sudo.cyberduck</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/DbVisualizer/DbVisualizer.pkg.recipe
+++ b/DbVisualizer/DbVisualizer.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.dbvis.DbVisualizer</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/DetectX/DetectX.pkg.recipe
+++ b/DetectX/DetectX.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.sqwarq.DetectX</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/Fiji/Fiji.pkg.recipe
+++ b/Fiji/Fiji.pkg.recipe
@@ -59,8 +59,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.fiji</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>scripts</key>
                   <string>Scripts</string>
                   <key>chown</key>

--- a/Geneious/Geneious.pkg.recipe
+++ b/Geneious/Geneious.pkg.recipe
@@ -66,8 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.biomatters.geneious</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/GoogleChrome/GoogleChrome.pkg.recipe
+++ b/GoogleChrome/GoogleChrome.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/GoogleChromeUniversal/GoogleChromeUniversal.pkg.recipe
+++ b/GoogleChromeUniversal/GoogleChromeUniversal.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/ImageJ/ImageJ.pkg.recipe
+++ b/ImageJ/ImageJ.pkg.recipe
@@ -30,8 +30,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>gov.nih.rsbweb.ImageJ</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/IntelliJ-CE/IntelliJ-CE.pkg.recipe
+++ b/IntelliJ-CE/IntelliJ-CE.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.jetbrains.intellij.ce</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/JQ/JQAppleSilicon.pkg.recipe
+++ b/JQ/JQAppleSilicon.pkg.recipe
@@ -87,8 +87,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.jqlang.jq.arm64.%version%</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/JQ/JQIntel.pkg.recipe
+++ b/JQ/JQIntel.pkg.recipe
@@ -87,8 +87,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.jqlang.jq.x8664.%version%</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/JQ/JQUniversal.pkg.recipe
+++ b/JQ/JQUniversal.pkg.recipe
@@ -87,8 +87,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.jqlang.jq.x8664.%version%</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -182,8 +180,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.jqlang.jq.arm64.%version%</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -325,8 +321,6 @@ exit 0</string>
                   <string>org.jqlang.jq.universal.%version%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/Maccy/Maccy.pkg.recipe
+++ b/Maccy/Maccy.pkg.recipe
@@ -72,8 +72,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>org.p0deje.Maccy</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/MalwarebytesAntiMalware/MalwarebytesAntiMalware.pkg.recipe
+++ b/MalwarebytesAntiMalware/MalwarebytesAntiMalware.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.malwarebytes.antimalware</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/MeisterTask/MeisterTask.pkg.recipe
+++ b/MeisterTask/MeisterTask.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.meisterlabs.meistertask.desktop</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/MicrosoftYammer/MicrosoftYammer.pkg.recipe
+++ b/MicrosoftYammer/MicrosoftYammer.pkg.recipe
@@ -74,8 +74,6 @@
                         <string>%version%</string>
                         <key>id</key>
                         <string>com.microsoft.Yammer</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/MindManager/MindManager.pkg.recipe
+++ b/MindManager/MindManager.pkg.recipe
@@ -70,8 +70,6 @@
                   <string>%RECIPE_CACHE_DIR%</string>
                   <key>id</key>
                   <string>%bundleid%</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/MountainDuck/MountainDuck.pkg.recipe
+++ b/MountainDuck/MountainDuck.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/OpenJDK11/OpenJDK11.pkg.recipe
+++ b/OpenJDK11/OpenJDK11.pkg.recipe
@@ -89,8 +89,6 @@
                   <string>net.java.openjdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK17/OpenJDKAppleSiliconJDK17.pkg.recipe
+++ b/OpenJDK17/OpenJDKAppleSiliconJDK17.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK17/OpenJDKIntelJDK17.pkg.recipe
+++ b/OpenJDK17/OpenJDKIntelJDK17.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK21/OpenJDKAppleSiliconJDK21.pkg.recipe
+++ b/OpenJDK21/OpenJDKAppleSiliconJDK21.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK21/OpenJDKIntelJDK21.pkg.recipe
+++ b/OpenJDK21/OpenJDKIntelJDK21.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK25/OpenJDKAppleSiliconJDK25.pkg.recipe
+++ b/OpenJDK25/OpenJDKAppleSiliconJDK25.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/OpenJDK25/OpenJDKIntelJDK25.pkg.recipe
+++ b/OpenJDK25/OpenJDKIntelJDK25.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.jdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/Prism/Prism.pkg.recipe
+++ b/Prism/Prism.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SapMachine/SapMachine.pkg.recipe
+++ b/SapMachine/SapMachine.pkg.recipe
@@ -122,8 +122,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK11/SapMachineAppleSiliconJDK11.pkg.recipe
+++ b/SapMachineJDK11/SapMachineAppleSiliconJDK11.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK11/SapMachineIntelJDK11.pkg.recipe
+++ b/SapMachineJDK11/SapMachineIntelJDK11.pkg.recipe
@@ -126,8 +126,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK11Universal/SapMachineJDK11Universal.pkg.recipe
+++ b/SapMachineJDK11Universal/SapMachineJDK11Universal.pkg.recipe
@@ -134,8 +134,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Intel/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -280,8 +278,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/AppleSilicon/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -413,8 +409,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.universal.%version%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/SapMachineJDK17/SapMachineAppleSiliconJDK17.pkg.recipe
+++ b/SapMachineJDK17/SapMachineAppleSiliconJDK17.pkg.recipe
@@ -128,8 +128,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK17/SapMachineIntelJDK17.pkg.recipe
+++ b/SapMachineJDK17/SapMachineIntelJDK17.pkg.recipe
@@ -128,8 +128,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK17Universal/SapMachineJDK17Universal.pkg.recipe
+++ b/SapMachineJDK17Universal/SapMachineJDK17Universal.pkg.recipe
@@ -136,8 +136,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Intel/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -284,8 +282,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/AppleSilicon/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -417,8 +413,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.universal.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/SapMachineJDK19Universal/SapMachineJDK19Universal.pkg.recipe
+++ b/SapMachineJDK19Universal/SapMachineJDK19Universal.pkg.recipe
@@ -136,8 +136,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Intel/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -284,8 +282,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/AppleSilicon/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -417,8 +413,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.universal.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/SapMachineJDK21/SapMachineAppleSiliconJDK21.pkg.recipe
+++ b/SapMachineJDK21/SapMachineAppleSiliconJDK21.pkg.recipe
@@ -128,8 +128,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK21/SapMachineIntelJDK21.pkg.recipe
+++ b/SapMachineJDK21/SapMachineIntelJDK21.pkg.recipe
@@ -128,8 +128,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/SapMachineJDK21Universal/SapMachineJDK21Universal.pkg.recipe
+++ b/SapMachineJDK21Universal/SapMachineJDK21Universal.pkg.recipe
@@ -136,8 +136,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.x8664.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Intel/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -284,8 +282,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.arm64.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/AppleSilicon/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>
@@ -417,8 +413,6 @@ exit 0</string>
                   <string>net.java.openjdk.sapmachine.universal.%version%.%BUILD_NUMBER%</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/Xcodes/Xcodes.pkg.recipe
+++ b/Xcodes/Xcodes.pkg.recipe
@@ -72,8 +72,6 @@
                   <string>%version%</string>
                   <key>id</key>
                   <string>com.xcodesorg.xcodesapp</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/iMazingProfileEditor/iMazingProfileEditor.pkg.recipe
+++ b/iMazingProfileEditor/iMazingProfileEditor.pkg.recipe
@@ -74,8 +74,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.DigiDNA.iMazingProfileEditorMac</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._