### PR TITLE
Update read me for triti-recipes deprecation

### DIFF
--- a/AdobeCreativeCloud/README.md
+++ b/AdobeCreativeCloud/README.md
@@ -25,6 +25,4 @@ The **AdobeCreativeCloudInstallerAppleSilicon** recipes will download the latest
 
 The **AdobeCreativeCloudInstallerUniversal** recipes will download the latest version of Adobe's Creative Cloud Installer for both Apple Silicon and Intel Macs. The **AdobeCreativeCloudInstallerUniversal.pkg** recipe will build an installer package which detects what kind of processor a Mac has (Intel or Apple Silicon) and installs the correct Creative Cloud desktop software for the Mac's processor.
 
-The `XMLReader` processor used by this recipe was written by Tyler Riti ([https://github.com/triti](https://github.com/triti)). The latest version of the processor is available from the following location:
-
-[https://github.com/autopkg/triti-recipes/tree/master/SharedProcessors](https://github.com/autopkg/triti-recipes/tree/master/SharedProcessors)
+The `XMLReader` processor used by this recipe was originally written by Tyler Riti ([https://github.com/triti](https://github.com/triti)).


### PR DESCRIPTION
With the upcoming [deprecation](https://github.com/autopkg/triti-recipes/issues/12) of triti-recipes, your copy of XMLReader is set to become the canonical copy in the AutoPkg org. (I've [reached out](https://github.com/autopkg/mikestechshop-recipes/issues/31) to the one other person using it, but haven't heard back.)

This PR updates your AdobeCreativeCloud recipes' read me to remove what will soon be a dead link.

Thanks!