### PR TITLE
Move `pkgname` key into `pkg_request` dictionary of PkgCreator arguments

### DIFF
--- a/CarouselCloudScreenSaver/CarouselCloudScreenSaver.pkg.recipe
+++ b/CarouselCloudScreenSaver/CarouselCloudScreenSaver.pkg.recipe
@@ -109,10 +109,10 @@ exit $ERROR</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-               <key>pkgname</key>
-               <string>%VENDOR%_%SOFTWARETITLE1%_%SOFTWARETITLE2%_%version%</string>
                <key>pkg_request</key>
                <dict>
+                  <key>pkgname</key>
+                  <string>%VENDOR%_%SOFTWARETITLE1%_%SOFTWARETITLE2%_%version%</string>
                   <key>version</key>
                   <string>%version%</string>
                   <key>id</key>

--- a/Maccy/Maccy.pkg.recipe
+++ b/Maccy/Maccy.pkg.recipe
@@ -64,10 +64,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-               <key>pkgname</key>
-               <string>%SOFTWARETITLE%_%version%</string>
                <key>pkg_request</key>
                <dict>
+                  <key>pkgname</key>
+                  <string>%SOFTWARETITLE%_%version%</string>
                   <key>version</key>
                   <string>%version%</string>
                   <key>id</key>

--- a/Xcodes/Xcodes.pkg.recipe
+++ b/Xcodes/Xcodes.pkg.recipe
@@ -64,10 +64,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-               <key>pkgname</key>
-               <string>%SOFTWARETITLE%_%version%</string>
                <key>pkg_request</key>
                <dict>
+                  <key>pkgname</key>
+                  <string>%SOFTWARETITLE%_%version%</string>
                   <key>version</key>
                   <string>%version%</string>
                   <key>id</key>


### PR DESCRIPTION
Although `pkgname` can technically live anywhere within the AutoPkg recipe since it can be read from the environment, it's conventional to put it where it's directly accessed: in the `pkg_request` dictionary alongside `version`, `id`, and other keys.

This PR makes that adjustment. Thanks for considering!

_Submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._