### PR TITLE
Adjust pkg certificate and asset regex for Aftermath

### DIFF
--- a/Aftermath/Aftermath.download.recipe
+++ b/Aftermath/Aftermath.download.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                <key>asset_regex</key>
-               <string>Aftermath.pkg</string>
+               <string>.+\.pkg$</string>
                <key>github_repo</key>
                <string>jamf/aftermath</string>
             </dict>
@@ -48,7 +48,7 @@
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Stuart Ashenbrenner (6PV5YF2UES)</string>
+                    <string>Developer ID Installer: JAMF Software (483DWKW443)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Aftermath/AftermathUninstaller.download.recipe
+++ b/Aftermath/AftermathUninstaller.download.recipe
@@ -50,7 +50,7 @@
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Stuart Ashenbrenner (6PV5YF2UES)</string>
+                    <string>Developer ID Installer: JAMF Software (483DWKW443)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
The pkg for the latest version of Aftermath is named slightly differently, and the signing certificate has been updated.

I've also updated the uninstaller recipe signing certificate, although the latest version of Aftermath does not include an uninstaller.

Download recipe verbose run output:

```
% autopkg run -vvq 'rtrouton-recipes/Aftermath/Aftermath.download.recipe'
Processing rtrouton-recipes/Aftermath/Aftermath.download.recipe...
WARNING: rtrouton-recipes/Aftermath/Aftermath.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.+\\.pkg$', 'github_repo': 'jamf/aftermath'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.+\.pkg$' among asset(s): aftermath-2.3.0.pkg
GitHubReleasesInfoProvider: Selected asset 'aftermath-2.3.0.pkg' from release '2.3.0'
{'Output': {'asset_created_at': '2025-09-25T20:39:00Z',
            'asset_url': 'https://api.github.com/repos/jamf/aftermath/releases/assets/297290907',
            'release_notes': "## What's Changed\r\n"
                             '* Fix issue when collecting launchd data by '
                             '@bartreardon in '
                             'https://github.com/jamf/aftermath/pull/62\r\n'
                             '* Fix tmp zip issue by @c7bercat in '
                             'https://github.com/jamf/aftermath/pull/67\r\n'
                             '* Timeline creation error fix by @c7bercat in '
                             'https://github.com/jamf/aftermath/pull/68\r\n'
                             '* Add provenance data collection support by '
                             '@kohnakagawa in '
                             'https://github.com/jamf/aftermath/pull/71\r\n'
                             '* Fixed long running processes @c7bercat '
                             'https://github.com/jamf/aftermath/pull/72',
            'url': 'https://github.com/jamf/aftermath/releases/download/v2.3.0/aftermath-2.3.0.pkg',
            'version': '2.3.0'}}
URLDownloader
{'Input': {'filename': 'Jamf_Aftermath_2.3.0.pkg',
           'url': 'https://github.com/jamf/aftermath/releases/download/v2.3.0/aftermath-2.3.0.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 25 Sep 2025 20:39:00 GMT
URLDownloader: Storing new ETag header: "0x8DDFC738F04821D"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/downloads/Jamf_Aftermath_2.3.0.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DDFC738F04821D"',
            'last_modified': 'Thu, 25 Sep 2025 20:39:00 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/downloads/Jamf_Aftermath_2.3.0.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/downloads/Jamf_Aftermath_2.3.0.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/downloads/Jamf_Aftermath_2.3.0.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Jamf_Aftermath_2.3.0.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-09-22 15:49:14 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: JAMF Software (483DWKW443)
CodeSignatureVerifier:        Expires: 2027-06-01 16:58:54 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CB 3C 51 9C E7 9B 47 8D 81 4A C7 FA 17 46 36 1F 9F 3C F9 5A 7B 48 
CodeSignatureVerifier:            92 E7 DF 0B 58 DD E1 EE 1B DD
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/receipts/Aftermath.download-receipt-20251025-232202.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.Aftermath/downloads/Jamf_Aftermath_2.3.0.pkg
```