### PR TITLE
Change Intel and Apple Silicon specific jq recipes to use gerardkok's jq.download

### DIFF
--- a/JQ/JQAppleIntel.sign.recipe
+++ b/JQ/JQAppleIntel.sign.recipe
@@ -10,9 +10,11 @@
       <dict>
          <key>SIGNINGCERTIFICATE</key>
          <string>Put_Signing_Certificate_into_AutoPkg_recipe_override</string>
+         <key>PLATFORM_ARCH</key>
+         <string>amd64</string>
       </dict>
       <key>ParentRecipe</key>
-      <string>com.github.rtrouton.pkg.JQIntel</string>
+      <string>com.github.gerardkok.pkg.jq</string>
       <key>Process</key>
       <array>
          <dict>

--- a/JQ/JQAppleSilicon.download.recipe
+++ b/JQ/JQAppleSilicon.download.recipe
@@ -19,6 +19,15 @@
       <string>1.0.0</string>
       <key>Process</key>
       <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the jq recipes in the gerardkok-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
          <dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>

--- a/JQ/JQAppleSilicon.sign.recipe
+++ b/JQ/JQAppleSilicon.sign.recipe
@@ -10,9 +10,11 @@
       <dict>
          <key>SIGNINGCERTIFICATE</key>
          <string>Put_Signing_Certificate_into_AutoPkg_recipe_override</string>
+         <key>PLATFORM_ARCH</key>
+         <string>arm64</string>
       </dict>
       <key>ParentRecipe</key>
-      <string>com.github.rtrouton.pkg.JQAppleSilicon</string>
+      <string>com.github.gerardkok.pkg.jq</string>
       <key>Process</key>
       <array>
          <dict>

--- a/JQ/JQIntel.download.recipe
+++ b/JQ/JQIntel.download.recipe
@@ -21,6 +21,15 @@
       <array>
          <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                  <key>warning_message</key>
+                  <string>Consider switching to the jq recipes in the gerardkok-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+         </dict>
+         <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The jq.download recipe in gerardkok-recipes supports downloading either Apple Silicon or Intel versions, and was created before the equivalent download recipe in this repo.

This PR adjusts the parent recipes and input variables such that the jq.sign recipes should still work with their specified architecture, but without maintaining redundant recipes.