### PR TITLE
Add code signature verification to SapMachine recipes

### DIFF
--- a/SapMachine/SapMachine.download.recipe
+++ b/SapMachine/SapMachine.download.recipe
@@ -45,6 +45,17 @@ Valid values for ARCH include:
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK11/SapMachineAppleSiliconJDK11.download.recipe
+++ b/SapMachineJDK11/SapMachineAppleSiliconJDK11.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK11/SapMachineIntelJDK11.download.recipe
+++ b/SapMachineJDK11/SapMachineIntelJDK11.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK11Universal/SapMachineJDK11Universal.download.recipe
+++ b/SapMachineJDK11Universal/SapMachineJDK11Universal.download.recipe
@@ -53,6 +53,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK17/SapMachineAppleSiliconJDK17.download.recipe
+++ b/SapMachineJDK17/SapMachineAppleSiliconJDK17.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK17/SapMachineIntelJDK17.download.recipe
+++ b/SapMachineJDK17/SapMachineIntelJDK17.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK17Universal/SapMachineJDK17Universal.download.recipe
+++ b/SapMachineJDK17Universal/SapMachineJDK17Universal.download.recipe
@@ -53,6 +53,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK19Universal/SapMachineJDK19Universal.download.recipe
+++ b/SapMachineJDK19Universal/SapMachineJDK19Universal.download.recipe
@@ -53,6 +53,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK21/SapMachineAppleSiliconJDK21.download.recipe
+++ b/SapMachineJDK21/SapMachineAppleSiliconJDK21.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK21/SapMachineIntelJDK21.download.recipe
+++ b/SapMachineJDK21/SapMachineIntelJDK21.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK21Universal/SapMachineJDK21Universal.download.recipe
+++ b/SapMachineJDK21Universal/SapMachineJDK21Universal.download.recipe
@@ -53,6 +53,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>

--- a/SapMachineJDK25/SapMachineAppleSiliconJDK25.download.recipe
+++ b/SapMachineJDK25/SapMachineAppleSiliconJDK25.download.recipe
@@ -38,6 +38,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
          </dict>
+         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%pathname%/sapmachine-jdk-*.jdk</string>
+               <key>requirement</key>
+               <string>identifier "com.sap.openjdk.jdk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7R5ZEU67FQ"</string>
+            </dict>
+         </dict>
       </array>
    </dict>
 </plist>


### PR DESCRIPTION
The .jdk files appear to be signed with a consistent signing certificate.

Some of the recipes are failing for unrelated reasons, but it's likely the same cert would be used to sign them if they get fixed in the future.

Output from CodeSignatureVerifier in modified recipes:

```
% autopkg run -vvq repos/autopkg/rtrouton-recipes/SapMachine*/*.download.* | grep -i codesignatureverifier
WARNING: repos/autopkg/rtrouton-recipes/SapMachine/SapMachine.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK11/SapMachineAppleSiliconJDK11.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
No release assets were found that satisfy the criteria.
Failed.
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK11/SapMachineIntelJDK11.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
No release assets were found that satisfy the criteria.
Failed.
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK11Universal/SapMachineJDK11Universal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
No release assets were found that satisfy the criteria.
Failed.
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK17/SapMachineAppleSiliconJDK17.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK17/SapMachineIntelJDK17.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK17Universal/SapMachineJDK17Universal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachine/downloads/sapmachine-jdk-17.0.17_macos-x64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.XYx7nb/sapmachine-jdk-17.0.17.jdk' matched from globbed '/private/tmp/dmg.XYx7nb/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.XYx7nb/sapmachine-jdk-17.0.17.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.XYx7nb/sapmachine-jdk-17.0.17.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.XYx7nb/sapmachine-jdk-17.0.17.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineAppleSiliconJDK17/downloads/sapmachine-jdk-17.0.17_macos-aarch64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.CxKPol/sapmachine-jdk-17.0.17.jdk' matched from globbed '/private/tmp/dmg.CxKPol/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.CxKPol/sapmachine-jdk-17.0.17.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.CxKPol/sapmachine-jdk-17.0.17.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.CxKPol/sapmachine-jdk-17.0.17.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK19Universal/SapMachineJDK19Universal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
No release assets were found that satisfy the criteria.
Failed.
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK21/SapMachineAppleSiliconJDK21.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineIntelJDK17/downloads/sapmachine-jdk-17.0.17_macos-x64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.kc0uDH/sapmachine-jdk-17.0.17.jdk' matched from globbed '/private/tmp/dmg.kc0uDH/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.kc0uDH/sapmachine-jdk-17.0.17.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.kc0uDH/sapmachine-jdk-17.0.17.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.kc0uDH/sapmachine-jdk-17.0.17.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK21/SapMachineIntelJDK21.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK21Universal/SapMachineJDK21Universal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineUniversalJDK17/downloads/sapmachine-jdk-17.0.17_macos-aarch64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.APboYO/sapmachine-jdk-17.0.17.jdk' matched from globbed '/private/tmp/dmg.APboYO/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.APboYO/sapmachine-jdk-17.0.17.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.APboYO/sapmachine-jdk-17.0.17.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.APboYO/sapmachine-jdk-17.0.17.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineAppleSiliconJDK21/downloads/sapmachine-jdk-21.0.9_macos-aarch64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.7l7LJH/sapmachine-jdk-21.0.9.jdk' matched from globbed '/private/tmp/dmg.7l7LJH/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.7l7LJH/sapmachine-jdk-21.0.9.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7l7LJH/sapmachine-jdk-21.0.9.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7l7LJH/sapmachine-jdk-21.0.9.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineIntelJDK21/downloads/sapmachine-jdk-21.0.9_macos-x64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.biGS2O/sapmachine-jdk-21.0.9.jdk' matched from globbed '/private/tmp/dmg.biGS2O/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.biGS2O/sapmachine-jdk-21.0.9.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.biGS2O/sapmachine-jdk-21.0.9.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.biGS2O/sapmachine-jdk-21.0.9.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
WARNING: repos/autopkg/rtrouton-recipes/SapMachineJDK25/SapMachineAppleSiliconJDK25.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
WARNING: repos/autopkg/rtrouton-recipes/SapMachineManager/SapMachineManager.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineUniversalJDK21/downloads/sapmachine-jdk-21.0.9_macos-aarch64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.iyTghF/sapmachine-jdk-21.0.9.jdk' matched from globbed '/private/tmp/dmg.iyTghF/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.iyTghF/sapmachine-jdk-21.0.9.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.iyTghF/sapmachine-jdk-21.0.9.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.iyTghF/sapmachine-jdk-21.0.9.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SapMachineAppleSiliconJDK25/downloads/sapmachine-jdk-25.0.1_macos-aarch64_bin.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.ZDQaXk/sapmachine-jdk-25.0.1.jdk' matched from globbed '/private/tmp/dmg.ZDQaXk/sapmachine-jdk-*.jdk'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ZDQaXk/sapmachine-jdk-25.0.1.jdk: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ZDQaXk/sapmachine-jdk-25.0.1.jdk: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ZDQaXk/sapmachine-jdk-25.0.1.jdk: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```