### PR TITLE
Deprecate Maccy recipes

### DIFF
--- a/Maccy/Maccy.download.recipe
+++ b/Maccy/Maccy.download.recipe
@@ -14,9 +14,18 @@
          <string>Maccy</string>
       </dict>
       <key>MinimumVersion</key>
-      <string>1.0.0</string>
+      <string>1.1</string>
       <key>Process</key>
       <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Maccy recipes in the skoobasteeve-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
          <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The Maccy recipes in this repo are similar in function to the earlier-created ones in skoobasteeve-recipes. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!