### PR TITLE
Deprecate Chrome Universal recipes

### DIFF
--- a/GoogleChromeUniversal/GoogleChromeUniversal.download.recipe
+++ b/GoogleChromeUniversal/GoogleChromeUniversal.download.recipe
@@ -16,9 +16,18 @@
         <string>https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the GoogleChrome recipes in the autopkg/recipes repo, which also download the Universal dmg for Chrome. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
The Google Chrome recipes in this repo are similar in function to the earlier-created ones in autopkg/recipes, which also download the Universal dmg installer for Chrome. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!