### PR TITLE
Deprecate LogiOptions recipes

### DIFF
--- a/LogiOptionsPlus/LogiOptionsPlus.download.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.download.recipe
@@ -20,9 +20,18 @@
          <string>OptionsPlus</string>
       </dict>
       <key>MinimumVersion</key>
-      <string>1.0.0</string>
+      <string>1.1</string>
       <key>Process</key>
       <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the logioptionsplus_installer recipes in the TekTekkers-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
          <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
The LogiOptionsPlus recipes in this repo are similar in function to the earlier-created ones in TekTekkers-recipes. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!