### PR TITLE
Update Adobe CCDA download recipes

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -17,10 +17,6 @@
 		<string>Creative Cloud Installer</string>
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
-		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>
 		<string>osx10</string>
 	</dict>
@@ -34,9 +30,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%SEARCH_URL%</string>
+				<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 				<key>re_pattern</key>
-				<string>%SEARCH_PATTERN%</string>
+				<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 			</dict>
 		</dict>
 		<dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstaller.download.recipe
@@ -11,12 +11,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Creative Cloud Installer</string>
-		<key>VENDOR</key>
-		<string>Adobe</string>
-		<key>SOFTWARETITLE</key>
-		<string>Creative Cloud Installer</string>
-		<key>NAMEWITHOUTSPACES</key>
-		<string>CreativeCloudInstaller</string>
 		<key>ARCHITECTURE</key>
 		<string>osx10</string>
 	</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
@@ -16,10 +16,6 @@
 		<string>Creative Cloud Installer</string>
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
-		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>ARCHITECTURE</key>
 		<string>macarm64</string>
 	</dict>
@@ -33,9 +29,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%SEARCH_URL%</string>
+				<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 				<key>re_pattern</key>
-				<string>%SEARCH_PATTERN%</string>
+				<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%ARCHITECTURE%/ACCC.*?.dmg)</string>
 			</dict>
 		</dict>
 		<dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe
@@ -10,12 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Creative Cloud Installer</string>
-		<key>VENDOR</key>
-		<string>Adobe</string>
-		<key>SOFTWARETITLE</key>
-		<string>Creative Cloud Installer</string>
-		<key>NAMEWITHOUTSPACES</key>
-		<string>CreativeCloudInstaller</string>
 		<key>ARCHITECTURE</key>
 		<string>macarm64</string>
 	</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -17,16 +17,6 @@
 		<string>Creative Cloud Installer</string>
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
-		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
-		<key>INTEL_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
-		<key>APPLE_SILICON_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
-		<key>INTEL_ARCHITECTURE</key>
-		<string>osx10</string>
-		<key>APPLE_SILICON_ARCHITECTURE</key>
-		<string>macarm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -38,9 +28,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%SEARCH_URL%</string>
+				<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 				<key>re_pattern</key>
-				<string>%INTEL_SEARCH_PATTERN%</string>
+				<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/osx10/ACCC.*?.dmg)</string>
 			</dict>
 		</dict>
 		<dict>
@@ -117,9 +107,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%SEARCH_URL%</string>
+				<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 				<key>re_pattern</key>
-				<string>%APPLE_SILICON_SEARCH_PATTERN%</string>
+				<string>(?P&lt;url&gt;http.*?://ccmdls?.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/macarm64/ACCC.*?.dmg)</string>
 			</dict>
 		</dict>
 		<dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -11,12 +11,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Creative Cloud Installer</string>
-		<key>VENDOR</key>
-		<string>Adobe</string>
-		<key>SOFTWARETITLE</key>
-		<string>Creative Cloud Installer</string>
-		<key>NAMEWITHOUTSPACES</key>
-		<string>CreativeCloudInstaller</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
This PR makes two changes in two separate commits.

**Move crucial variables from input to process**
This commit moves crucial variables from the Input to the Process based on this conversation in Slack: https://macadmins.slack.com/archives/C056155B4/p1768935875961799

This change is needed so that any updates to the URL or regex are automatically applied to everyone using these parent recipes.

With the variables as part of the input, fixes made to these parent recipes are not automatically applied downstream and users are required both to update trust and manually edit their overrides to include the upstream changes.

**Remove unneeded variables from Download recipes**
This commit removes unneeded variables from the download recipes that only apply to the PKG recipes (where they also exist).

This prevents the variables from showing up in other recipes (Munki) that use the Download recipes as a parent, but are not needed.

**Logs**
-vv runs of each edited recipe are attached.
[AdobeCreativeCloudInstaller.download.recipe.log](https://github.com/user-attachments/files/24899091/AdobeCreativeCloudInstaller.download.recipe.log)
[AdobeCreativeCloudInstallerAppleSilicon.download.recipe.log](https://github.com/user-attachments/files/24899092/AdobeCreativeCloudInstallerAppleSilicon.download.recipe.log)
[AdobeCreativeCloudInstallerUniversal.download.recipe.log](https://github.com/user-attachments/files/24899093/AdobeCreativeCloudInstallerUniversal.download.recipe.log)
