### PR TITLE
Fix input key request_headers

### DIFF
--- a/Busylight/Busylight.download.recipe
+++ b/Busylight/Busylight.download.recipe
@@ -34,7 +34,7 @@
 			<dict>
 				<key>filename</key>
 				<string>%VENDOR%-%SOFTWARETITLE1%-%SOFTWARETITLE2%-%SOFTWARETITLE3%-%SOFTWARETITLE4%.zip</string>
-				<key>request-headers</key>
+				<key>request_headers</key>
 				<dict>
 					<key>user-agent</key>
 					<string>%DOWNLOAD_USERAGENT%</string>


### PR DESCRIPTION
The input key “request-headers” did not match the “request_headers” input key expected by the URLDownloader Processor. The input key was then not used by URLDownloader.

URLDownloader failed to download the requested URL without the modified, non-default “user-agent”. Download attempts resulted in an HTTP 403 error.

With the correct input key, the “user-agent” was added to the download request, which then succeeded.