### PR TITLE
Change MS Teams to %PRODUCTID%

### DIFF
--- a/MicrosoftTeams/MicrosoftTeams.download.recipe
+++ b/MicrosoftTeams/MicrosoftTeams.download.recipe
@@ -16,48 +16,23 @@
          <string>Microsoft</string>
          <key>SOFTWARETITLE</key>
          <string>Teams</string>
+         <key>PRODUCTID</key>
+         <string>2249065</string>
+         <key>DOWNLOADURL</key>
+         <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
       </dict>
       <key>Process</key>
       <array>
          <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>filename</key>
-               <string>0409TEAMS21-chk.plist</string>
-               <key>download_dir</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%</string>
-               <key>url</key>
-               <string>https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409TEAMS21-chk.xml</string>
-            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-         </dict>
-         <dict>
             <key>Arguments</key>
             <dict>
-               <key>info_path</key>
-               <string>%RECIPE_CACHE_DIR%/%VENDOR%/0409TEAMS21-chk.plist</string>
-               <key>plist_keys</key>
-               <dict>
-                  <key>Update Version</key>
-                  <string>DOWNLOAD_VERSION</string>
-               </dict>
-            </dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
+               <key>url</key>
+               <string>%DOWNLOADURL%</string>
                <key>filename</key>
                <string>%VENDOR%_%SOFTWARETITLE%.pkg</string>
-                <key>download_dir</key>
-                <string>%RECIPE_CACHE_DIR%/downloads</string>
-               <key>url</key>
-               <string>https://statics.teams.cdn.office.net/production-osx/%DOWNLOAD_VERSION%/MicrosoftTeams.pkg</string>
             </dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
          </dict>
          <dict>
             <key>Processor</key>
@@ -77,17 +52,6 @@
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
-         </dict>
-         <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-               <key>path_list</key>
-               <array>
-                  <string>%RECIPE_CACHE_DIR%/%VENDOR%</string>
-               </array>
-            </dict>
          </dict>
       </array>
    </dict>


### PR DESCRIPTION
Hi @rtrouton,

As mentioned in Issue #258, the XML that was used before seems to be outdated. According to Microsoft's [release notes](https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning), the current version 26163.407.4839.8659 was released on July 1 and is downloaded.

This PR aligns the download recipe to the office apps (Excel, Outlook, …) and is working with the `.pkg` recipe, too.

Please see the output of `autopkg run -vvq com.github.rtrouton.download.microsoftteams`:

```
Processing com.github.rtrouton.download.microsoftteams...
WARNING: com.github.rtrouton.download.microsoftteams is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Microsoft_Teams.pkg',
           'url': 'https://go.microsoft.com/fwlink/?linkid=2249065'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 01 Jul 2026 08:25:03 GMT
URLDownloader: Storing new ETag header: "0x8DED74A402B5E34"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/downloads/Microsoft_Teams.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DED74A402B5E34"',
            'last_modified': 'Wed, 01 Jul 2026 08:25:03 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/downloads/Microsoft_Teams.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/downloads/Microsoft_Teams.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Microsoft '
                                        'Corporation (UBF8T346G9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/downloads/Microsoft_Teams.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Microsoft_Teams.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-06-23 22:55:40 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            64 5D 86 D2 DF 76 9E D7 04 CF B1 FA 1B 38 7F 78 69 DC 87 12 AB 4E
CodeSignatureVerifier:            0F BC EB BC 29 64 D3 E9 A9 48
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/receipts/com.github.rtrouton.download-receipt-20260714-163747.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/com.github.rtrouton.download.microsoftteams/downloads/Microsoft_Teams.pkg
```
The version can be checked by running the `.pkg` recipe or (of course) by inspecting the downloaded pkg.